### PR TITLE
Fix Admin redirection after login.

### DIFF
--- a/front/website/ts/components/login/controllers/LoginCtrl.ts
+++ b/front/website/ts/components/login/controllers/LoginCtrl.ts
@@ -63,7 +63,7 @@ export class LoginCtrl {
 				() => {
 					this.$http.get("/api/me")
 						.success((res: any) => {
-							if (res.isAdmin === true) {
+							if (res.IsAdmin === true) {
 								this.$location.path("/admin");
 							} else {
 								this.$location.path("/");


### PR DESCRIPTION
Not sure if it's better to expect this variable to be called «IsAdmin» or change the backend to return «isAdmin».