### PR TITLE
Fix file upload

### DIFF
--- a/src/nanocloud/upload.go
+++ b/src/nanocloud/upload.go
@@ -69,12 +69,23 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	chunkNum := r.FormValue("flowChunkNumber")
-	totalChunks := r.FormValue("flowTotalChunks")
+
+	chunkNum, err := strconv.Atoi(r.FormValue("flowChunkNumber"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	totalChunks, err := strconv.Atoi(r.FormValue("flowTotalChunks"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	filename := r.FormValue("flowFilename")
 	// module := r.FormValue("module")
 
-	err = writeChunk(filepath.Join(userPath, "incomplete", filename), chunkNum, r)
+	err = writeChunk(filepath.Join(userPath, "incomplete", filename), strconv.Itoa(chunkNum), r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -170,6 +181,7 @@ func syncUploadedFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	cmd := exec.Command(filepath.Join(dir, "scripts", "copy.sh"), filepath.Join(dir, path))
 	cmd.Dir = filepath.Join(dir, "scripts")
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
The uploaded file chunks were not assembled successfully. The system started the rebuild before he got every chunks.
The update of the nano package consists of using incremental int to uniquely identify every RPC request. The previous method used to use random strings that were not random enough.