### PR TITLE
Ignore extra comas and vendor content in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,9 @@
 engines:
   eslint:
     enabled: true
-  duplication:
+    checks:
+      comma-dangle:
+        enabled: false
     enabled: true
     config:
       languages:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,3 +14,4 @@ ratings:
 exclude_paths:
   - tests/api/**
   - assets/tests/**
+  - assets/vendor/**


### PR DESCRIPTION
Code climate used to report lot of errors regarding trailing commas. Tailing comas are legal in ES and are a good help to generate easy to version code.
Also, minified assets/vendor/guacamole-common-js used to report a lot of error.
