### PR TITLE
Configurator service added

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,6 @@ ratings:
   paths:
   - "**.js"
 exclude_paths:
-  - tests/api/**
+  - tests/**
   - assets/tests/**
   - assets/vendor/**

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ tests:
 test-api:
 	mocha tests/api/bootstrap.test.js tests/api/index.js
 
+test-units:
+	mocha ./tests/unit/**/*.js
+
 test-jshint:
 	jshint api/ config/
 

--- a/api/hooks/config.js
+++ b/api/hooks/config.js
@@ -1,0 +1,20 @@
+const ConfigService = require('../services/ConfigService');
+
+module.exports = function(sails) {
+  return {
+    initialize(done) {
+      sails.after('hook:orm:loaded', () => {
+        return ConfigService.init()
+        .then(() => {
+          sails.emit('hook:config:loaded');
+          done();
+        })
+        .catch((err) => {
+          if (err) {
+            throw new Error('Fail to initialize config.');
+          }
+        });
+      });
+    }
+  };
+};

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -7,8 +7,17 @@
 
 module.exports = {
 
+  autoPK: false,
   attributes: {
 
+    key: {
+      primaryKey: true,
+      type: 'string'
+    },
+
+    value: {
+      type: 'string'
+    }
   }
 };
 

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -1,0 +1,176 @@
+/* globals Config */
+
+const Promise = require('bluebird');
+
+/**
+ * nanocloudConfigValue returns the value associated to the config variable's
+ * name. It will retreive the value from the environment variable if any and
+ * ensure that the type of the varriable is the same as the defaultValue.
+ * If default value is an object, the environment variable is expected to be a
+ * serialized JSON object.
+ * It it's an array, it's expected to be a serialized JSON array.
+ * Otherwise, it returns the defaultValue.
+ *
+ * @method nanocloudConfigValue
+ * @private
+ * @param {String} name Name of the config variable
+ * @param {String} defaultValue The value to return if the environment variable
+ * "name" is not set.
+ * @return {Object} The environment variable if found (casted to the type of
+ * defaultValue). defaultValue otherwise.
+ */
+function nanocloudConfigValue(name, defaultValue) {
+  let value;
+
+  if (process.env.hasOwnProperty(name)) {
+    let type;
+
+    let value = process.env[name];
+
+    if (Array.isArray(defaultValue)) {
+      type = 'array';
+    } else {
+      type = (typeof defaultValue);
+    }
+
+    switch (type) {
+      case 'number':
+        value = parseInt(value, 10);
+        if (Number.isNaN(value)) {
+          throw new Error(`Config variable '${name}' must be an number.`);
+        }
+        break;
+
+      case 'array':
+        value = JSON.parse(value);
+        if (!Array.isArray(value)) {
+          throw new Error(`Config variable '${name}' must be an array.`);
+        }
+        break;
+
+      case 'object':
+        value = JSON.parse(value);
+        if (typeof value !== 'object') {
+          throw new Error(`Config variable '${name}' must be an object.`);
+        }
+        break;
+
+      case 'boolean':
+        if (value === 'true') {
+          value = true;
+        } else if (value === 'false') {
+          value = false;
+        }
+        throw new Error(`Config variable '${name}' must be an boolean.`);
+
+   // case 'string':
+   //   value = value;
+   //   break;
+
+    }
+  } else {
+    value = defaultValue;
+  }
+
+  return value;
+}
+
+/**
+ * get retreives the values of the specified config variables.
+ *
+ * @method get
+ * @public
+ * @param {[]String} keys The names of the variable to retreive
+ * @return {Promise[Object]} A promise that resolves a hash of the retreived
+ * variables
+ */
+function get(...keys) {
+  return new Promise((resolve, reject) => {
+    Config.find({
+      key: keys
+    }, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        let rt = {};
+        res.forEach((row) => {
+          rt[row.key] = row.value;
+        });
+        resolve(rt);
+      }
+    });
+  });
+}
+
+/**
+ * set saves the specified configuration variable in the database.
+ * If the variable exists already, the value is updated.
+ *
+ * @method set
+ * @public
+ * @param {String} key The name of the variable to create
+ * @param {String} value The value of the variable to create
+ * @return {Promise[null]}
+ */
+function set(key, value) {
+  return new Promise((resolve, reject) => {
+    Config.query({
+      text: `INSERT INTO
+      config ("key", "value", "createdAt", "updatedAt")
+      VALUES($1::varchar, $2::varchar, NOW(), NOW())
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value,
+      "updatedAt" = NOW()`,
+      values: [key, value]
+    }, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * init initializes the ConfigService. It will copy the configuration variables
+ * found in `config.nanocloud` in the database.
+ *
+ * @method init
+ * @private
+ * @param {Function} callback Completion callback
+ * @return {Promise[null]}
+ */
+function init(callback) {
+  const config = sails.config.nanocloud;
+  let actions = [];
+
+  for (let name in config) {
+    if (config.hasOwnProperty(name)) {
+      actions.push(set(name, nanocloudConfigValue(name, config[name])));
+    }
+  }
+
+  return Promise.all(actions).then(callback, callback);
+}
+
+/**
+ * unset deletes the config variable named in the `keys` parameter.
+ *
+ * @method unset
+ * @public
+ * @param {[]String} keys The names of the keys to delete
+ * @return {Promise[null]}
+ */
+function unset(...keys) {
+  return new Promise((resolve, reject) => {
+    Config.destroy(keys, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+module.exports = { get, set, unset, init };

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -4,11 +4,11 @@ const Promise = require('bluebird');
 
 /**
  * nanocloudConfigValue returns the value associated to the config variable's
- * name. It will retreive the value from the environment variable if any and
+ * name. It will retrieve the value from the environment variable if any and
  * ensure that the type of the varriable is the same as the defaultValue.
  * If default value is an object, the environment variable is expected to be a
  * serialized JSON object.
- * It it's an array, it's expected to be a serialized JSON array.
+ * If it's an array, it's expected to be a serialized JSON array.
  * Otherwise, it returns the defaultValue.
  *
  * @method nanocloudConfigValue

--- a/package.json
+++ b/package.json
@@ -49,9 +49,10 @@
   "license": "AGPL-3.0",
   "devDependencies": {
     "ajv": "^4.1.7",
+    "chai": "^3.5.0",
     "clone": "^1.0.2",
-    "jsonapi-validator": "^2.1.0",
     "jshint": "^2.9.2",
+    "jsonapi-validator": "^2.1.0",
     "mocha": "2.4.5",
     "supertest": "^1.2.0"
   }

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -13,4 +13,6 @@ function check_command {
 
 check_command make test-jshint
 check_command make test-api
+check_command make test-units
+
 exit $EXIT_STATUS

--- a/tests/unit/services/ConfigService.test.js
+++ b/tests/unit/services/ConfigService.test.js
@@ -1,0 +1,104 @@
+// jshint mocha:true
+
+/* global ConfigService */
+
+var Promise = require('bluebird');
+var assert = require('chai').assert;
+var sails = require('sails');
+
+process.env.IAAS = 'dummy';
+
+before(function(done) {
+
+  // Increase the Mocha timeout so that Sails has enough time to lift.
+  this.timeout(5000);
+
+  sails.lift({
+    models: {
+      migrate: 'drop'
+    }
+  }, (err) => {
+
+    if (err) {
+      throw new Error(err);
+    }
+
+    ConfigService.init()
+    .then(() => {
+      return done(null, sails);
+    }, done);
+
+  });
+});
+
+describe('Config single Get/Set/Unset', () => {
+  it('Should retrieve the recorded value', (done) => {
+
+    (function() {
+
+      return ConfigService.set('NANOCLOUD', 'nanocloud')
+      .then(() => {
+        return ConfigService.get('NANOCLOUD');
+      })
+      .then((res) => {
+        assert.deepEqual({ NANOCLOUD: 'nanocloud' }, res);
+
+        return ConfigService.unset('NANOCLOUD')
+        .then(() => {
+          return ConfigService.get('NANOCLOUD')
+          .then((res) => {
+            assert.deepEqual({}, res);
+          });
+        });
+      });
+
+    })()
+
+    .then(() => done()).catch(done);
+
+  });
+});
+
+describe('Config multiple Get/Set/Unset', () => {
+  it('Should retrieve the recorded values', (done) => {
+
+    (function() {
+
+      return Promise.all([
+        ConfigService.set('NANOCLOUD', 'nanocloud'),
+        ConfigService.set('FOO', 'foo'),
+        ConfigService.set('BAR', 'bar'),
+        ConfigService.set('BAZ', 'baz')
+      ])
+      .then(() => {
+        return ConfigService.get(
+          'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+        );
+      })
+      .then((res) => {
+        assert.deepEqual({
+          NANOCLOUD: 'nanocloud',
+          FOO: 'foo',
+          BAR: 'bar',
+          BAZ: 'baz'
+        }, res);
+
+        return ConfigService.unset(
+          'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+        )
+        .then(() => {
+          return ConfigService.get(
+            'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+          )
+          .then((res) => {
+            assert.deepEqual({}, res);
+          });
+        });
+      });
+
+    })()
+
+    .then(() => done()).catch(done);
+
+  });
+});


### PR DESCRIPTION
This add the `Config` model, the `ConfigService` and the `config` hooks. The `ConfigService` is used to retrieve, set and remove nanocloud's configuration variables.
