### PR TITLE
Add history endpoint

### DIFF
--- a/api/models/History.js
+++ b/api/models/History.js
@@ -25,10 +25,54 @@
  * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
  */
 
+const uuid = require('node-uuid');
+
 module.exports = {
 
-  attributes: {
+  autoPK: false,
 
+  attributes: {
+    id: {
+      type: 'string',
+      primaryKey: true,
+      unique: true,
+      index: true,
+      uuidv4: true,
+      defaultsTo: function (){ return uuid.v4(); }
+	},
+    userMail: {
+      type: 'string'
+    },
+    userFirstname: {
+      type: 'string'
+    },
+    userLastname: {
+      type: 'string'
+    },
+    userId: {
+	  type: 'string'
+	},
+    connectionId: {
+	  type: 'string'
+	},
+    startDate: {
+	  type: 'string'
+	},
+    endDate: {
+      type: 'string'
+	},
+    machineId: {
+	  type: 'string'
+	},
+	machineSize: {
+	  type: 'string'
+    },
+    machineDriver: {
+	  type: 'string'
+	},
+    duration: {
+	  type: 'string'
+	}
   }
 };
 

--- a/api/models/History.js
+++ b/api/models/History.js
@@ -39,7 +39,7 @@ module.exports = {
       index: true,
       uuidv4: true,
       defaultsTo: function (){ return uuid.v4(); }
-	},
+    },
     userMail: {
       type: 'string'
     },
@@ -50,29 +50,29 @@ module.exports = {
       type: 'string'
     },
     userId: {
-	  type: 'string'
-	},
+      type: 'string'
+    },
     connectionId: {
-	  type: 'string'
-	},
+      type: 'string'
+    },
     startDate: {
-	  type: 'string'
-	},
+      type: 'string'
+    },
     endDate: {
       type: 'string'
-	},
+    },
     machineId: {
-	  type: 'string'
-	},
-	machineSize: {
-	  type: 'string'
+      type: 'string'
+    },
+    machineSize: {
+      type: 'string'
     },
     machineDriver: {
-	  type: 'string'
-	},
+      type: 'string'
+    },
     duration: {
-	  type: 'string'
-	}
+      type: 'string'
+    }
   }
 };
 

--- a/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NanocloudHttpConnection.java
+++ b/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NanocloudHttpConnection.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 public class NanocloudHttpConnection {
 
-		private static Logger logger = LoggerFactory.getLogger(NanocloudHttpConnection.class);
+  private static Logger logger = LoggerFactory.getLogger(NanocloudHttpConnection.class);
   private NanocloudHttpConnection() {
 
   }

--- a/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NanocloudHttpConnection.java
+++ b/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/NanocloudHttpConnection.java
@@ -17,8 +17,11 @@ import java.lang.reflect.Field;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 public class NanocloudHttpConnection {
 
+		private static Logger logger = LoggerFactory.getLogger(NanocloudHttpConnection.class);
   private NanocloudHttpConnection() {
 
   }
@@ -62,6 +65,8 @@ public class NanocloudHttpConnection {
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
+    } catch (final Exception e) {
+      logger.info(e.toString());
     }
   }
 

--- a/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
+++ b/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
@@ -78,8 +78,8 @@ public class LoggedConnection extends SimpleConnection {
       resp = NanocloudHttpConnection.HttpGet("http://" + hostname + ":" + port + "/api/machines/users", token);
       JSONArray dataArray = resp.getJSONArray("data");
       data = dataArray.getJSONObject(0);
+      String machineId = data.getString("id");
       dataAttribute = data.getJSONObject("attributes");
-      String machineId = dataAttribute.getString("id");
       String machineSize = dataAttribute.getString("machine-size");
       String machineDriver = dataAttribute.getString("platform");
 
@@ -202,8 +202,8 @@ public class LoggedConnection extends SimpleConnection {
         JSONObject resp = NanocloudHttpConnection.HttpGet("http://" + hostname + ":" + port + "/api/machines/users", token);
         JSONArray dataArray = resp.getJSONArray("data");
         JSONObject data = dataArray.getJSONObject(0);
+        String machineId = data.getString("id");
         JSONObject dataAttribute = data.getJSONObject("attributes");
-        String machineId = dataAttribute.getString("id");
         String machineSize = dataAttribute.getString("machine-size");
         String machineDriver = dataAttribute.getString("platform");
 
@@ -231,14 +231,13 @@ public class LoggedConnection extends SimpleConnection {
         urlConn.setUseCaches(false);
         urlConn.setDoOutput(true);
         // Send request (for some reason we actually need to wait for response)
-        OutputStream os = urlConn.getOutputStream();
-        NanocloudHttpConnection.setRequestMethodUsingWorkaroundForJREBug(urlConn, "PATCH");
-        DataOutputStream writer = new DataOutputStream(os);
+        NanocloudHttpConnection.setRequestMethodUsingWorkaroundForJREBug(urlConn, "POST");
+        DataOutputStream writer = new DataOutputStream(urlConn.getOutputStream());
         writer.writeBytes(params.toString());
         writer.close();
 
         urlConn.connect();
-        os.close();
+        urlConn.getOutputStream().close();
 
         // Get Response
         InputStream input = urlConn.getInputStream();

--- a/tests/api/histories.test.js
+++ b/tests/api/histories.test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 // jshint mocha:true
 
 var nano = require('./lib/nanotest');
@@ -8,8 +32,8 @@ module.exports = function() {
   describe("Histories", function() {
 
     afterEach('Cleaning database', function () {
-	  Histories.query('TRUNCATE TABLE public.history', done);
-	});
+      Histories.query('TRUNCATE TABLE public.history', done);
+    });
 
     const expectedSchema = {
       type: 'object',
@@ -18,13 +42,13 @@ module.exports = function() {
         'user-id': {type: 'string'},
         'user-firstname': {type: 'string'},
         'user-lastname': {type: 'string'},
-		'connection-id': {type: 'string'},
-		'start-date': {type: 'string'},
-		'end-date': {type: 'string'},
-		'machine-id': {type: 'string'},
-		'machine-size': {type: 'string'},
-		'machine-driver': {type: 'string'},
-		'duration': {type: 'string'},
+        'connection-id': {type: 'string'},
+        'start-date': {type: 'string'},
+        'end-date': {type: 'string'},
+        'machine-id': {type: 'string'},
+        'machine-size': {type: 'string'},
+        'machine-driver': {type: 'string'},
+        'duration': {type: 'string'},
         'created-at': {type: 'string'},
         'updated-at': {type: 'string'}
       },
@@ -32,7 +56,7 @@ module.exports = function() {
       additionalProperties: false
     };
 
-	describe("Create history", () => {
+    describe("Create history", () => {
       it('Should create history', (done) => {
         nano.request(sails.hooks.http.app)
           .post('/api/histories')
@@ -43,13 +67,13 @@ module.exports = function() {
                 'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
                 'user-firstname': 'Admin',
                 'user-lastname': 'Nanocloud',
-		        'connection-id': 'Desktop',
-		        'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
-		        'end-date': '',
-	        	'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
-		        'machine-size': '',
-		        'machine-driver': 'dummy',
-		        'duration': null
+                'connection-id': 'Desktop',
+                'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+                'end-date': '',
+                'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
+                'machine-size': '',
+                'machine-driver': 'dummy',
+                'duration': null
               },
               type: 'histories'
             }
@@ -57,45 +81,46 @@ module.exports = function() {
           .set('Authorization', 'Bearer admintoken')
           .expect(201)
           .expect(nano.jsonApiSchema(expectedSchema))
-		  .then((res) => {
-			return nano.request(sails.hooks.http.app)
-			  .get('/api/hitories')
-			  .expect(200)
-			  .expect(nano.jsonApiSchema(expectedSchema))
-			  .expect((res) => {
-			    expect(res.body.data[0].attributes.startDate).to.equal('Wed Jul 21 14:10:00 UTC 2016');
-			  });
-		  })
-		  .then((res) => {
-			return nano.request(sailt.hooks.http.app)
-			  .post('/api/histories/' + res.body.data[0].id)
-			  .send({
-                data: {
-                  attributes: {
-                    'user-mail': 'admin@nanocloud.com',
-                    'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
-                    'user-firstname': 'Admin',
-                    'user-lastname': 'Nanocloud',
-		            'connection-id': 'Desktop',
-		            'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
-		            'end-date': 'Wed Jul 21 14:20:00 UTC 2016',
-	            	'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
-		            'machine-size': '',
-		            'machine-driver': 'dummy',
-		            'duration': null
-                  },
-                  type: 'histories'
-                }
-			  })
+          .then((res) => {
+            return nano.request(sails.hooks.http.app)
+              .get('/api/hitories')
               .set('Authorization', 'Bearer admintoken')
               .expect(200)
               .expect(nano.jsonApiSchema(expectedSchema))
-			  .expect((res) => {
-			    expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
-			  });
-		  })
-          .end(done);
-	  });
+              .expect((res) => {
+                expect(res.body.data[0].attributes.startDate).to.equal('Wed Jul 21 14:10:00 UTC 2016');
+              });
+          })
+        .then((res) => {
+          return nano.request(sailt.hooks.http.app)
+            .post('/api/histories/' + res.body.data[0].id)
+            .send({
+              data: {
+                attributes: {
+                  'user-mail': 'admin@nanocloud.com',
+                  'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                  'user-firstname': 'Admin',
+                  'user-lastname': 'Nanocloud',
+                  'connection-id': 'Desktop',
+                  'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+                  'end-date': 'Wed Jul 21 14:20:00 UTC 2016',
+                  'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
+                  'machine-size': '',
+                  'machine-driver': 'dummy',
+                  'duration': null
+                },
+                type: 'histories'
+              }
+            })
+            .set('Authorization', 'Bearer admintoken')
+            .expect(200)
+            .expect(nano.jsonApiSchema(expectedSchema))
+            .expect((res) => {
+              expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
+            });
+        })
+        .end(done);
+      });
 
       it('Should return created history', (done) => {
         nano.request(sails.hooks.http.app)
@@ -103,12 +128,12 @@ module.exports = function() {
           .set('Authorization', 'Bearer admintoken')
           .expect(200)
           .expect(nano.jsonApiSchema(expectedSchema))
-		  .expect((res) => {
-			 expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
-		  })
+          .expect((res) => {
+             expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
+          })
           .end(done);
-	  });
+      });
 
-	});
+    });
   });
 };

--- a/tests/api/histories.test.js
+++ b/tests/api/histories.test.js
@@ -1,0 +1,114 @@
+// jshint mocha:true
+
+var nano = require('./lib/nanotest');
+var expect = require('chai').expect;
+
+module.exports = function() {
+
+  describe("Histories", function() {
+
+    afterEach('Cleaning database', function () {
+	  Histories.query('TRUNCATE TABLE public.history', done);
+	});
+
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        'user-mail': {type: 'string'},
+        'user-id': {type: 'string'},
+        'user-firstname': {type: 'string'},
+        'user-lastname': {type: 'string'},
+		'connection-id': {type: 'string'},
+		'start-date': {type: 'string'},
+		'end-date': {type: 'string'},
+		'machine-id': {type: 'string'},
+		'machine-size': {type: 'string'},
+		'machine-driver': {type: 'string'},
+		'duration': {type: 'string'},
+        'created-at': {type: 'string'},
+        'updated-at': {type: 'string'}
+      },
+      required: ['user-mail','user-id','user-firstname','user-lastname','connection-id','start-date','end-date','machine-id','machine-size','machine-driver','created-at','updated-at'],
+      additionalProperties: false
+    };
+
+	describe("Create history", () => {
+      it('Should create history', (done) => {
+        nano.request(sails.hooks.http.app)
+          .post('/api/histories')
+          .send({
+            data: {
+              attributes: {
+                'user-mail': 'admin@nanocloud.com',
+                'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                'user-firstname': 'Admin',
+                'user-lastname': 'Nanocloud',
+		        'connection-id': 'Desktop',
+		        'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+		        'end-date': '',
+	        	'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
+		        'machine-size': '',
+		        'machine-driver': 'dummy',
+		        'duration': null
+              },
+              type: 'histories'
+            }
+          })
+          .set('Authorization', 'Bearer admintoken')
+          .expect(201)
+          .expect(nano.jsonApiSchema(expectedSchema))
+		  .then((res) => {
+			return nano.request(sails.hooks.http.app)
+			  .get('/api/hitories')
+			  .expect(200)
+			  .expect(nano.jsonApiSchema(expectedSchema))
+			  .expect((res) => {
+			    expect(res.body.data[0].attributes.startDate).to.equal('Wed Jul 21 14:10:00 UTC 2016');
+			  });
+		  })
+		  .then((res) => {
+			return nano.request(sailt.hooks.http.app)
+			  .post('/api/histories/' + res.body.data[0].id)
+			  .send({
+                data: {
+                  attributes: {
+                    'user-mail': 'admin@nanocloud.com',
+                    'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                    'user-firstname': 'Admin',
+                    'user-lastname': 'Nanocloud',
+		            'connection-id': 'Desktop',
+		            'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+		            'end-date': 'Wed Jul 21 14:20:00 UTC 2016',
+	            	'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
+		            'machine-size': '',
+		            'machine-driver': 'dummy',
+		            'duration': null
+                  },
+                  type: 'histories'
+                }
+			  })
+              .set('Authorization', 'Bearer admintoken')
+              .expect(200)
+              .expect(nano.jsonApiSchema(expectedSchema))
+			  .expect((res) => {
+			    expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
+			  });
+		  })
+          .end(done);
+	  });
+
+      it('Should return created history', (done) => {
+        nano.request(sails.hooks.http.app)
+          .get('/api/histories')
+          .set('Authorization', 'Bearer admintoken')
+          .expect(200)
+          .expect(nano.jsonApiSchema(expectedSchema))
+		  .expect((res) => {
+			 expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
+		  })
+          .end(done);
+	  });
+
+	});
+  });
+};


### PR DESCRIPTION
Fix the history endpoint.

Add some modifications on guacamole calls to history endpoint.
guacamole do a first post request for create an history without enddate when the vm is started, and a second post on the id used on the first post ("/api/histories/:id") for update the end date when the vm is stopped.

Add a model for history.
Add the required model

Add to test to verify the histories endpoint.
