### PR TITLE
Deserialize configuration values in their original types

### DIFF
--- a/api/controllers/Reset-passwordController.js
+++ b/api/controllers/Reset-passwordController.js
@@ -80,7 +80,7 @@ module.exports = {
       return EmailService.sendMail(user.email, subject, message);
     })
     .then(() => {
-      return res.ok({});
+      return res.json({meta: {}});
     })
     .catch((err) => {
       if (err.message === "No user found") {
@@ -148,4 +148,3 @@ module.exports = {
     });
   }
 };
-

--- a/api/hooks/config.js
+++ b/api/hooks/config.js
@@ -22,23 +22,38 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-const ConfigService = require('../services/ConfigService');
+/* global ConfigService */
 
-module.exports = function(sails) {
+/**
+ * @module hooks
+ * @class Config
+ * @param {Object} sails The sails application
+ */
+function Config(sails) {
   return {
+
+    /**
+     * Initialize the hook
+     *
+     * @method initialize
+     * @param {Function} done Callback of the initialization
+     */
     initialize(done) {
       sails.after('hook:orm:loaded', () => {
-        return ConfigService.init()
+        ConfigService.init()
         .then(() => {
           sails.emit('hook:config:loaded');
           done();
         })
         .catch((err) => {
           if (err) {
-            throw new Error('Fail to initialize config.');
+            sails.log.error('Fail to initialize config.');
+            done(err);
           }
         });
       });
     }
   };
-};
+}
+
+module.exports = Config;

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -229,7 +229,7 @@ function set(key, value) {
   let expectedType = getVariableType(key);
 
   if (type !== expectedType) {
-    return Promise.reject(new Error(`Invalid data type. Exepected ${expectedType}. Got ${type}.`));
+    return Promise.reject(new Error(`Invalid data type for ${key}. Expected ${expectedType}. Got ${type}.`));
   }
 
   switch (type) {
@@ -243,9 +243,6 @@ function set(key, value) {
       break;
 
     case 'boolean':
-      value = (value) ? 'true' : 'false';
-      break;
-
     case 'string':
       // value = value;
       break;

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -16,16 +16,98 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General
- * Public License
- * along with this program.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* globals Config */
 
 const Promise = require('bluebird');
 const _ = require('lodash');
+
+/**
+ * Return the type of val. It is similar to typeof except that it returns
+ * 'array' for arrays
+ *
+ * @method typeOf
+ * @private
+ * @param {Object} val The variable from which the type will be returned
+ * @return {String}
+ */
+function typeOf(val) {
+  const type = (typeof val);
+  if (type === 'object' && Array.isArray(val)) {
+    return 'array';
+  }
+  return type;
+}
+
+/**
+ * Return the type for config variable name
+ *
+ * @method getVariableType
+ * @private
+ * @return {String}
+ */
+function getVariableType(name) {
+  return typeOf(sails.config.nanocloud[name]);
+}
+
+/**
+ * Deserialize value according to the type of the default value of 'name'
+ *
+ * @method deserialize
+ * @private
+ * @param {String} name The name of the config variable
+ * @param {Object} value The value to be deserialized
+ * @return {Object} The deserilazied value.
+ */
+function deserialize(name, value) {
+  switch (getVariableType(name)) {
+    case 'number':
+      value = parseInt(value, 10);
+      if (Number.isNaN(value)) {
+        throw new Error(`Config variable '${name}' must be an number.`);
+      }
+      break;
+
+    case 'array':
+      value = JSON.parse(value);
+      if (!Array.isArray(value)) {
+        throw new Error(`Config variable '${name}' must be an array.`);
+      }
+      break;
+
+    case 'object':
+      try {
+        value = JSON.parse(value);
+
+        if (typeof value !== 'object' || Array.isArray(value)) {
+          throw new Error(`Config variable '${name}' must be an object.`);
+        }
+      } catch (e) {
+        throw new Error(`Config variable '${name}' must be an object.`);
+      }
+      break;
+
+    case 'boolean':
+      if (value === 'true') {
+        value = true;
+      } else if (value === 'false') {
+        value = false;
+      } else {
+        throw new Error(`Config variable '${name}' must be an boolean.`);
+      }
+      break;
+
+   case 'string':
+     break;
+
+   default:
+     throw new Error(`Config variable '${name}' as an invalid value.`);
+  }
+  return value;
+}
 
 /**
  * nanocloudConfigValue returns the value associated to the config variable's
@@ -99,7 +181,7 @@ function nanocloudConfigValue(name, defaultValue) {
 
     }
   } else {
-    value = defaultValue;
+    return defaultValue;
   }
 
   return value;
@@ -124,7 +206,7 @@ function get(...keys) {
       } else {
         let rt = {};
         res.forEach((row) => {
-          rt[row.key] = row.value;
+          rt[row.key] = deserialize(row.key, row.value);
         });
         resolve(rt);
       }
@@ -143,6 +225,35 @@ function get(...keys) {
  * @return {Promise[null]}
  */
 function set(key, value) {
+  let type = typeOf(value);
+  let expectedType = getVariableType(key);
+
+  if (type !== expectedType) {
+    return Promise.reject(new Error(`Invalid data type. Exepected ${expectedType}. Got ${type}.`));
+  }
+
+  switch (type) {
+    case 'number':
+      value = value.toString();
+      break;
+
+    case 'array':
+    case 'object':
+      value = JSON.stringify(value);
+      break;
+
+    case 'boolean':
+      value = (value) ? 'true' : 'false';
+      break;
+
+    case 'string':
+      // value = value;
+      break;
+
+    default:
+      return Promise.reject(new Error(`Invalid data type ${type}`));
+  }
+
   return new Promise((resolve, reject) => {
     Config.query({
       text: `INSERT INTO

--- a/api/services/EmailService.js
+++ b/api/services/EmailService.js
@@ -49,7 +49,7 @@ function sendMail(to, subject, message) {
         }
       };
 
-      if (configs.testMail === 'true') {
+      if (configs.testMail === true) {
         smtpConfig = stubTransport();
       }
 

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -56,6 +56,8 @@ module.exports = {
     smtpSendFrom: 'mail@nanocloud.com',
     testMail: false,
     storageAddress: 'localhost',
-    storagePort: 9090
+    storagePort: 9090,
+
+    iaas: 'manual'
   }
 };

--- a/tests/api/auto-signup.test.js
+++ b/tests/api/auto-signup.test.js
@@ -31,10 +31,14 @@ module.exports = function() {
 
   describe("Auto sign-up", function() {
 
-    before(function() {
-      ConfigService.set('testMail', true);
+    before(function(done) {
       // it takes time to send a mail with nodemailer
       this.timeout(10000);
+
+      ConfigService.set('testMail', true)
+        .then(() => {
+          return done();
+        });
     });
 
     const expectedSchema = {

--- a/tests/api/reset-password.test.js
+++ b/tests/api/reset-password.test.js
@@ -32,13 +32,16 @@ module.exports = function() {
 
   describe("Reset password", function() {
 
-    before(function() {
-      ConfigService.set('testSendMail', true);
-    });
-
     const expectedSchema = {};
 
     describe("Create a reset password token", function() {
+
+      before(function(done) {
+        ConfigService.set('testMail', true)
+          .then(() => {
+            return done();
+          });
+      });
 
       it('Should return empty meta', function(done) {
 
@@ -63,7 +66,7 @@ module.exports = function() {
         // test token creation
         .then(() => {
           // adding token to 'reset-password' table
-          nano.request(sails.hooks.http.app)
+          return nano.request(sails.hooks.http.app)
           .post('/api/reset-passwords')
           .send({
             data: {
@@ -76,7 +79,9 @@ module.exports = function() {
           })
           .set(nano.adminLogin())
           .expect(200)
-          .expect(nano.jsonApiSchema(expectedSchema))
+          .expect({
+            meta: {}
+          })
           .then(() => {
             // token has been added to 'reset-password' table
             return (nano.request(sails.hooks.http.app)
@@ -92,13 +97,16 @@ module.exports = function() {
           });
         })
         .then(() => {
-          return done(); 
+          return done();
         })
       });
     });
 
-    after(function() {
-      ConfigService.unset('testSendMail');
+    after(function(done) {
+      ConfigService.unset('testMail')
+        .then(() => {
+          return done();
+        });
     });
   });
 };

--- a/tests/unit/services/ConfigService.test.js
+++ b/tests/unit/services/ConfigService.test.js
@@ -37,16 +37,16 @@ describe('Config single Get/Set/Unset', () => {
 
     (function() {
 
-      return ConfigService.set('NANOCLOUD', 'nanocloud')
+      return ConfigService.set('host', 'nanocloud')
       .then(() => {
-        return ConfigService.get('NANOCLOUD');
+        return ConfigService.get('host');
       })
       .then((res) => {
-        assert.deepEqual({ NANOCLOUD: 'nanocloud' }, res);
+        assert.deepEqual({ host: 'nanocloud' }, res);
 
-        return ConfigService.unset('NANOCLOUD')
+        return ConfigService.unset('host')
         .then(() => {
-          return ConfigService.get('NANOCLOUD')
+          return ConfigService.get('host')
           .then((res) => {
             assert.deepEqual({}, res);
           });
@@ -66,30 +66,26 @@ describe('Config multiple Get/Set/Unset', () => {
     (function() {
 
       return Promise.all([
-        ConfigService.set('NANOCLOUD', 'nanocloud'),
-        ConfigService.set('FOO', 'foo'),
-        ConfigService.set('BAR', 'bar'),
-        ConfigService.set('BAZ', 'baz')
+        ConfigService.set('host', 'nanocloud'),
+        ConfigService.set('iaas', 'foo'),
       ])
       .then(() => {
         return ConfigService.get(
-          'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+          'host', 'iaas'
         );
       })
       .then((res) => {
         assert.deepEqual({
-          NANOCLOUD: 'nanocloud',
-          FOO: 'foo',
-          BAR: 'bar',
-          BAZ: 'baz'
+          host: 'nanocloud',
+          iaas: 'foo'
         }, res);
 
         return ConfigService.unset(
-          'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+          'host', 'iaas'
         )
         .then(() => {
           return ConfigService.get(
-            'NANOCLOUD', 'FOO', 'BAR', 'BAZ'
+            'host', 'iaas'
           )
           .then((res) => {
             assert.deepEqual({}, res);


### PR DESCRIPTION
Forces values coming out of the configurator to be cast in their original type.
'true' -> true
Object[array] -> array.

Update `ConfigService` unit test to fit the new behavior. Since `config/env/*.js` serves as reference for typing, it is now impossible to add variable that are not defined in this file.
