### PR TITLE
Add expiration date to user accounts

### DIFF
--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -93,8 +93,6 @@ module.exports = {
     ConfigService.get('expirationDate')
     .then((conf) => {
       expirationDays = conf.expirationDate;
-    })
-    .then(() => {
       return PendingUser.findOne({
         "id": pendingUserID
       });

--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -97,7 +97,7 @@ module.exports = {
     .then(() => {
       return PendingUser.findOne({
         "id": pendingUserID
-      })
+      });
     })
     .then((user) => {
       if (!user) {

--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -31,7 +31,8 @@
 /* globals JsonApiService */
 /* globals User */
 
-const uuid = require('node-uuid');
+const uuid    = require('node-uuid');
+const moment  = require('moment');
 
 module.exports = {
 
@@ -65,7 +66,7 @@ module.exports = {
       var to =  user.email;
       var subject = 'Nanocloud - Verify your email address';
       var message = 'Hello ' + user["first-name"] + ' ' + user["last-name"] + ',<br> please verify your email address by clicking this link: '+
-          '<a href="http://'+host+'/#/activate/'+user.id+'">Activate my account</a>';
+          '<a href="'+host+'/#/activate/'+user.id+'">Activate my account</a>';
 
       return EmailService.sendMail(to, subject, message)
       .then(() => {
@@ -86,14 +87,23 @@ module.exports = {
   },
 
   update: function(req, res) {
-    let pendingUserID = req.params.id;
-    PendingUser.findOne({
-      "id": pendingUserID
+    var pendingUserID = req.params.id;
+    var expirationDays;
+
+    ConfigService.get('expirationDate')
+    .then((conf) => {
+      expirationDays = conf.expirationDate;
+    })
+    .then(() => {
+      return PendingUser.findOne({
+        "id": pendingUserID
+      })
     })
     .then((user) => {
       if (!user) {
         return res.notFound('No user found');
       }
+      user['expirationDate'] = moment().add(expirationDays, 'days').unix();
       User.create(user)
       .then(() => {
           return PendingUser.destroy({

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -52,6 +52,9 @@ module.exports = {
     isAdmin: {
       type: 'boolean'
     },
+    expirationDate: {
+      type: 'integer'
+    },
 
     toJSON: function() {
       var obj = this.toObject();

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -33,7 +33,7 @@ export default Ember.Service.extend({
     "sessionDuration",
     "smtpServerHost",
     "smtpServerPort",
-    "expirationDays",
+    "expirationDate",
     "smtpLogin",
     "smtpPassword",
     "smtpSendFrom",

--- a/assets/app/protected/configs/user-right/template.hbs
+++ b/assets/app/protected/configs/user-right/template.hbs
@@ -36,7 +36,7 @@
     <div class="col-sm-2">
       <p class="confirm-input-item color-primary">You can enter an expiration date for new users (in days):</p>
     </div>
-    <div class="col-sm-2">{{input-confirm value=configController.expirationDays type="number" min="1"}}</div>
+    <div class="col-sm-2">{{input-confirm value=configController.expirationDate type="number" min="1"}}</div>
   </div>
 {{/if}}
 <div>

--- a/assets/app/protected/users/new/controller.js
+++ b/assets/app/protected/users/new/controller.js
@@ -37,6 +37,10 @@ export default Ember.Controller.extend({
         .validate()
         .then(({ m, validations }) => {
 
+          let expirationDate = this.get('model.expirationDate');
+          let timestamp = window.moment().add(expirationDate, 'days').unix();
+          this.set('model.expirationDate', timestamp);
+
           if (validations.get('isInvalid') === true) {
             return this.toast.error('Cannot create user');
           }

--- a/assets/app/protected/users/new/controller.js
+++ b/assets/app/protected/users/new/controller.js
@@ -38,7 +38,8 @@ export default Ember.Controller.extend({
         .then(({ m, validations }) => {
 
           let expirationDate = this.get('model.expirationDate');
-          let timestamp = window.moment().add(expirationDate, 'days').unix();
+          let timestamp = (expirationDate) ?
+            (window.moment().add(expirationDate, 'days').unix()) : (null);
           this.set('model.expirationDate', timestamp);
 
           if (validations.get('isInvalid') === true) {

--- a/assets/app/protected/users/new/template.hbs
+++ b/assets/app/protected/users/new/template.hbs
@@ -11,7 +11,7 @@
         {{nano-input hideError=userHasSubmitted placeholder='Email address' model=model valuePath="email"}}
         {{nano-input hideError=userHasSubmitted placeholder='Password' type="password" model=model valuePath="password"}}
         {{nano-input hideError=userHasSubmitted placeholder='Password confirmation' type="password" model=model valuePath="passwordConfirmation"}}
-        {{nano-input hideError=userHasSubmitted placeholder='Days left before expiration' model=model valuePath="expirationDays"}}
+        {{nano-input hideError=userHasSubmitted placeholder='Days left before expiration' model=model valuePath="expirationDate"}}
 
         {{#if loadState}}
           <button type="submit" class="btn btn-info btn-block text-uppercase">

--- a/assets/app/protected/users/user/controller.js
+++ b/assets/app/protected/users/user/controller.js
@@ -154,6 +154,16 @@ export default Ember.Controller.extend({
             this.toast.error(this.get('model.validations.attrs.expirationDate.messages'));
             return defer.reject(this.get('model.validations.attrs.expirationDate.messages'));
           }
+          let expirationDays = this.get('expirationDays');
+          let timestamp = window.moment().add(expirationDays, 'days').unix();
+
+          if (this.get('model.expirationDays.length') > 3
+              || expirationDays < 0) {
+            this.toast.error("Expiration date has not been updated");
+            return defer.reject();
+          }
+
+          this.set('model.expirationDate', timestamp);
           this.model.save()
             .then(() => {
               defer.resolve();

--- a/assets/app/protected/users/user/controller.js
+++ b/assets/app/protected/users/user/controller.js
@@ -155,10 +155,11 @@ export default Ember.Controller.extend({
             return defer.reject(this.get('model.validations.attrs.expirationDate.messages'));
           }
           let expirationDays = this.get('expirationDays');
-          let timestamp = window.moment().add(expirationDays, 'days').unix();
+          let timestamp = (expirationDays > 0) ?
+            (window.moment().add(expirationDays, 'days').unix()) : (0);
 
-          if (this.get('model.expirationDays.length') > 3
-              || expirationDays < 0) {
+          if (this.get('model.expirationDays.length') > 3 ||
+              expirationDays < 0) {
             this.toast.error("Expiration date has not been updated");
             return defer.reject();
           }

--- a/assets/app/protected/users/user/controller.js
+++ b/assets/app/protected/users/user/controller.js
@@ -147,12 +147,12 @@ export default Ember.Controller.extend({
     changeExpirationDays: function(defer) {
 
       this.get('model')
-        .validate({ on: ['expirationDays'] })
+        .validate({ on: ['expirationDate'] })
         .then(({ m, validations }) => {
 
           if (validations.get('isInvalid') === true) {
-            this.toast.error(this.get('model.validations.attrs.expirationDays.messages'));
-            return defer.reject(this.get('model.validations.attrs.expirationDays.messages'));
+            this.toast.error(this.get('model.validations.attrs.expirationDate.messages'));
+            return defer.reject(this.get('model.validations.attrs.expirationDate.messages'));
           }
           this.model.save()
             .then(() => {

--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -93,13 +93,13 @@
 				{{#edit-text
 					type="number"
 					confirmation=false
-					textInput=model.expirationDays
+					textInput=model.expirationDate
 					textInputPlaceholder="Days left before expiration"
 					onClose="changeExpirationDays" }}
-						{{moment-calendar model.expirationDays}}
+						{{moment-calendar model.expirationDate}}
 						{{/edit-text}}
 				{{else}}
-						 {{moment-calendar model.expirationDays}}
+						 {{moment-calendar model.expirationDate}}
 				{{/if}}
           </td>
 		</tr>

--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -89,18 +89,22 @@
 		<tr>
           <th scope="row">Expiration date</th>
           <td>
-				{{#if session.user.isAdmin }}
-				{{#edit-text
-					type="number"
-					confirmation=false
-					textInput=model.expirationDate
-					textInputPlaceholder="Days left before expiration"
-					onClose="changeExpirationDays" }}
-						{{moment-calendar model.expirationDate}}
-						{{/edit-text}}
-				{{else}}
-						 {{moment-calendar model.expirationDate}}
-				{{/if}}
+              {{#if session.user.isAdmin }}
+                  {{#edit-text
+                    type="number"
+                    confirmation=false
+                    textInput=expirationDays
+                    textInputPlaceholder="Days left before expiration"
+                    onClose="changeExpirationDays" }}
+                        {{#if model.expirationDate}}
+                          {{moment-calendar model.expirationDateInMs}}
+                        {{else}}
+                          No expiration date set
+                        {{/if}}
+                    {{/edit-text}}
+              {{else}}
+                  {{moment-calendar model.expirationDate}}
+              {{/if}}
           </td>
 		</tr>
         <tr>

--- a/assets/app/user/model.js
+++ b/assets/app/user/model.js
@@ -70,6 +70,7 @@ const Validations = buildValidations({
     validator('number', {
       allowBlank: true,
       integer: true,
+      allowString: true,
     })
   ]
 });

--- a/assets/app/user/model.js
+++ b/assets/app/user/model.js
@@ -65,7 +65,7 @@ const Validations = buildValidations({
     validator('presence', true),
     validator('format', { type: 'email' })
   ],
-  expirationDays: [
+  expirationDate: [
     validator('length', { max: 6 }),
     validator('number', {
       allowString: true,
@@ -84,7 +84,7 @@ export default DS.Model.extend(Validations, {
   lastName: DS.attr('string'),
   password: DS.attr('string'),
   signupDate: DS.attr('number'),
-  expirationDays: DS.attr('string'),
+  expirationDate: DS.attr('number'),
 
   fullName: function() {
     if (this.get('firstName') && this.get('lastName')) {

--- a/assets/app/user/model.js
+++ b/assets/app/user/model.js
@@ -66,11 +66,9 @@ const Validations = buildValidations({
     validator('format', { type: 'email' })
   ],
   expirationDate: [
-    validator('length', { max: 6 }),
+    validator('length', { max: 3 }),
     validator('number', {
-      allowString: true,
-	  allowBlank: true,
-      positive: true,
+      allowBlank: true,
       integer: true,
     })
   ]
@@ -78,13 +76,16 @@ const Validations = buildValidations({
 
 export default DS.Model.extend(Validations, {
   email: DS.attr('string'),
-  activated: DS.attr('boolean'),
   isAdmin: DS.attr('boolean'),
   firstName: DS.attr('string'),
   lastName: DS.attr('string'),
   password: DS.attr('string'),
   signupDate: DS.attr('number'),
   expirationDate: DS.attr('number'),
+
+  expirationDateInMs: Ember.computed('expirationDate', function() {
+    return this.get('expirationDate') * 1000;
+  }),
 
   fullName: function() {
     if (this.get('firstName') && this.get('lastName')) {

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -57,6 +57,7 @@ module.exports = {
     testMail: false,
     storageAddress: 'localhost',
     storagePort: 9090,
+    expirationDate: 0,
 
     iaas: 'manual'
   }

--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -46,6 +46,10 @@ server.exchange(oauth2orize.exchange.password(function(user, username, password,
       done(err);
     }
 
+    // delete reset password tokens
+    global['Reset-password'].destroy({
+      email: user.email
+    });
     RefreshToken.create({
       userId: user.id
     }, function(err, refreshToken){

--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -38,7 +38,8 @@ server.exchange(oauth2orize.exchange.password(function(user, username, password,
     email: username,
     or: [
       { expirationDate: { '>' : Math.floor(new Date() / 1000)  } },
-      { expirationDate: null  }
+      { expirationDate: null },
+      { expirationDate: 0 }
     ]
   }, function(err, user) {
 

--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -45,6 +45,9 @@ server.exchange(oauth2orize.exchange.password(function(user, username, password,
     if (err) {
       done(err);
     }
+    if (!user) {
+      return done(user);
+    }
 
     // delete reset password tokens
     global['Reset-password'].destroy({

--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -35,7 +35,11 @@ var server = oauth2orize.createServer();
 server.exchange(oauth2orize.exchange.password(function(user, username, password, scope, done) {
 
   User.findOne({
-    email: username
+    email: username,
+    or: [
+      { expirationDate: { '>' : Math.floor(new Date() / 1000)  } },
+      { expirationDate: null  }
+    ]
   }, function(err, user) {
 
     if (err) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request": "^2.74.0",
     "request-promise": "^4.1.0",
     "sails": "~0.12.3",
-    "sails-json-api-blueprints": "0.10.0",
+    "sails-json-api-blueprints": "0.10.1",
     "sails-postgresql": "^0.11.4",
     "sails-seed": "^0.4.5",
     "sha1": "^1.1.1",

--- a/tests/api/auto-signup.test.js
+++ b/tests/api/auto-signup.test.js
@@ -53,7 +53,7 @@ module.exports = function() {
         'updated-at': {type: 'string'},
       },
       required: ['first-name', 'last-name', 'hashed-password', 'email', 'is-admin', 'created-at', 'updated-at'],
-      additionalProperties: false,
+      additionalProperties: true, // expiration days
     };
 
     const userData = {

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -29,6 +29,7 @@ const testUsers = require('./users.test');
 const testAutoSignup = require('./auto-signup.test');
 const testResetPassword = require('./reset-password.test');
 const testStorage = require('./storage.test');
+const testUserLimitation = require('./user-limitation.test');
 
 var request = require('supertest');
 
@@ -47,3 +48,4 @@ testUsers();
 testAutoSignup();
 testResetPassword();
 testStorage();
+testUserLimitation();

--- a/tests/api/user-limitation.test.js
+++ b/tests/api/user-limitation.test.js
@@ -1,0 +1,114 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+// jshint mocha:true
+
+var nano = require('./lib/nanotest');
+
+module.exports = function() {
+
+  describe("User limitation", function() {
+
+    describe("Create user with in future expiration date", function() {
+
+      it('Should return created user', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .post('/api/users')
+          .send({
+            data: {
+              attributes: {
+                'first-name': "Future",
+                'last-name': "Date",
+                'email': "futuredate@nanocloud.com",
+                'password': "nanocloud",
+                'is-admin': false,
+                'expiration-date': 1543681605
+              },
+              type: 'users'
+            }
+          })
+          .set(nano.adminLogin())
+          .expect(201)
+          .end(done);
+      });
+
+      it('Should return valid token', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .post('/oauth/token')
+          .send({
+            "username": "futuredate@nanocloud.com",
+            "password": "nanocloud",
+            "grant_type": "password"
+          })
+        .set('Authorization', 'Basic ' + new Buffer('9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341').toString('base64'))
+          .expect(200)
+          .expect((res) => {
+            if (res.body.token_type !== 'Bearer') {
+              throw new Error("token_type should be Bearer");
+            }
+          })
+        .end(done);
+      });
+    });
+
+    describe("Create user with in past expiration date", function() {
+
+      it('Should return created user', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .post('/api/users')
+          .send({
+            data: {
+              attributes: {
+                'first-name': "Past",
+                'last-name': "Date",
+                'email': "pastdate@nanocloud.com",
+                'password': "nanocloud",
+                'is-admin': false,
+                'expiration-date': 1
+              },
+              type: 'users'
+            }
+          })
+          .set(nano.adminLogin())
+          .expect(201)
+          .end(done);
+      });
+
+      it('Should return login error', function(done) {
+        nano.request(sails.hooks.http.app)
+          .post('/oauth/token')
+          .send({
+            "username": "pastdate@nanocloud.com",
+            "password": "nanocloud",
+            "grant_type": "password"
+          })
+        .set('Authorization', 'Basic ' + new Buffer('9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341').toString('base64'))
+          .end(done);
+      });
+    });
+  });
+};

--- a/tests/api/users.test.js
+++ b/tests/api/users.test.js
@@ -42,7 +42,7 @@ module.exports = function() {
         'updated-at': {type: 'string'}
       },
       required: ['email', 'hashed-password', 'is-admin', 'first-name', 'last-name', 'created-at', 'updated-at'],
-      additionalProperties: false
+      additionalProperties: true // expiration date is not mandatory
     };
 
     describe("Create user", function() {
@@ -58,7 +58,8 @@ module.exports = function() {
                 'last-name': "Lastname",
                 'email': "user@nanocloud.com",
                 'password': "nanocloud",
-                'is-admin': false
+                'is-admin': false,
+                'expiration-date': null
               },
               type: 'users'
             }


### PR DESCRIPTION
When admin creates a user he can set an expiration date.
A user can not log in if he have exceeded his expiration date.

A new config variable allows admin to set a default number of days before account is deactivated for self registered users.
