### PR TITLE
Add an upload limit for user

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AWS driver specific
 Storage specific:
 - STORAGE_ADDRESS (mandatory, defaults to 'localhost') storage service's IP
 - STORAGE_PORT (mandatory, defaults to 9090) storage service's port
+- UPLOAD_LIMIT (defaults 0 (desactivated)) upload limit, in MB, for each user
 
 Once loaded, Nanocloud will be accessible on **localhost**.
 

--- a/api/services/StorageService.js
+++ b/api/services/StorageService.js
@@ -22,10 +22,11 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* globals Storage, ConfigService */
+/* globals Storage, ConfigService, PlazaService */
 
 const randomstring = require("randomstring");
 const sha1 = require("sha1");
+const Promise = require("bluebird");
 
 module.exports = {
 
@@ -92,5 +93,59 @@ module.exports = {
       return true;
     }
     return false;
+  },
+
+  /**
+   * checkUploadLimit
+   *
+   * Check if the upload limit is reached
+   *
+   * @param {Object} Storage of user want to upload
+   * @param {number} Length in byte of the new file
+   * @return {Promise[object|null]} Error object if upload limit is reached, null in other cases
+   */
+  checkUploadLimit: function(storage, length) {
+    return ConfigService.get('uploadLimit')
+      .then((limit) => {
+        return this.storageSize(storage, "", length)
+          .then((size) => {
+            return new Promise(function(resolve, reject) {
+              //limit["uploadLimit"] is in Mo
+              if (limit["uploadLimit"] !== '0' && size > limit["uploadLimit"] * 1048576) {
+                return reject({
+                  statusCode: 403,
+                  message: "The upload limit is reached"
+                });
+              }
+              return resolve(null);
+            });
+          });
+      });
+  },
+
+  /**
+   * storageSize
+   *
+   * Calculate sum of files size recursively
+   *
+   * @param {Object} Storage of user want to upload
+   * @param {string} Directory where we search files
+   * @param {number} Sum of files size
+   * @return {number} Sum of files size
+   */
+  storageSize: function(storage, dir, sum) {
+    return PlazaService.files(storage, "/home/" + storage.username + "/" + dir)
+      .then((files) => {
+        return new Promise(function(resolve) {
+          for (let i = 0; i < files.data.length; i++) {
+            if (files.data[i].attributes.type === "directory") {
+              sum += this.storageSize(storage, files.data[i].attributes.name + "/" + dir, 0);
+            } else {
+              sum += files.data[i].attributes.size;
+            }
+          }
+          return resolve(sum);
+        });
+      });
   }
 };

--- a/api/services/StorageService.js
+++ b/api/services/StorageService.js
@@ -110,8 +110,8 @@ module.exports = {
         return this.storageSize(storage, "", length)
           .then((size) => {
             return new Promise(function(resolve, reject) {
-              //limit["uploadLimit"] is in Mo
-              if (limit["uploadLimit"] !== '0' && size > limit["uploadLimit"] * 1048576) {
+              // limit["uploadLimit"] is in MB
+              if (limit["uploadLimit"] !== 0 && size > limit["uploadLimit"] * 1048576) {
                 return reject({
                   statusCode: 403,
                   message: "The upload limit is reached"

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -58,6 +58,7 @@ module.exports = {
     testMail: false,
     storageAddress: 'localhost',
     storagePort: 9090,
+    uploadLimit: 0,
     expirationDate: 0,
     autoRegister: false,
     autoLogoff: false,

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -41,6 +41,20 @@ server {
         proxy_connect_timeout 600s;
     }
 
+    location /api/upload {
+        proxy_pass http://backend:1337/api/upload ;
+        proxy_set_header Accept-Encoding "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_connect_timeout 600s;
+        client_max_body_size 0;
+        proxy_request_buffering off;
+    }
+
     location /guacamole/ {
         proxy_pass http://guacamole-client:8080/guacamole/ ;
         proxy_buffering off;

--- a/proxy/nginx.dev.conf
+++ b/proxy/nginx.dev.conf
@@ -41,6 +41,20 @@ server {
         proxy_connect_timeout 600s;
     }
 
+    location /api/upload {
+        proxy_pass http://localhost:1337/api/upload ;
+        proxy_set_header Accept-Encoding "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        proxy_connect_timeout 600s;
+        client_max_body_size 0;
+        proxy_request_buffering off;
+    }
+
     location /guacamole/ {
         proxy_pass http://localhost:8080/guacamole/ ;
         proxy_buffering off;


### PR DESCRIPTION
When users upload a file we check if upload limit is reached or not.
- checkUploadLimit function is called in upload endpoint.
- You can configure the upload limit, in Mo, with the UPLOAD_LIMIT global in config.env.
- By default uploadLimit is set at 0 (desactivated).
- Update Readme.
- Add tests for new functions in StorageService.
- Update nginx configs for upload.
- Add appropriate notification in front.
