### PR TITLE
Give a recognizable name to CVS history dumps

### DIFF
--- a/assets/app/download-csv/service.js
+++ b/assets/app/download-csv/service.js
@@ -27,11 +27,9 @@ import formatTimeDuration from 'nanocloud/utils/format-duration';
 
 export default Ember.Service.extend({
 
-  downloadCSV(accessToken, model) {
+  getCsvBase64(accessToken, model) {
 
-    var csvContent = "data:text/csv;charset=utf-8,";
-
-    csvContent += "USERNAME,USERID,CONNECTION,START,END,DURATION\n"; 
+    var csvContent = "USERNAME,USERID,CONNECTION,START,END,DURATION\n"; 
 
     model.forEach(function(item) {
       csvContent += 
@@ -42,8 +40,6 @@ export default Ember.Service.extend({
         item.get('endDate') + ',' +
         formatTimeDuration(item.get('duration') / 1000) + '\n';
     });
-
-    let url = encodeURI(csvContent);
-    window.location.assign(url);
+    return btoa(csvContent);
   }
 });

--- a/assets/app/protected/histories/index/controller.js
+++ b/assets/app/protected/histories/index/controller.js
@@ -139,16 +139,11 @@ export default Ember.Controller.extend({
 
   downloadCsvLink: Ember.computed(function() {
     let content = this.get('downloadCSVService').getCsvBase64(this.get('sessionService.access_token'), this.get('items'));
-
-    var link = "data:text/csv;base64,";
-    link+=content;
-    
-    return link;
+    return "data:text/csv;base64," + content;
   }),
 
   downloadCsvFilename: Ember.computed(function() {
     let current_date = window.moment(new Date()).format('YYYY-MM-DD');
-    let filename = "nanocloud-history-" + current_date;
-    return filename;
+    return "nanocloud-history-" + current_date;
   })
 });

--- a/assets/app/protected/histories/index/controller.js
+++ b/assets/app/protected/histories/index/controller.js
@@ -137,9 +137,18 @@ export default Ember.Controller.extend({
     }
   ],
 
-  actions: {
-    downloadCSV() {
-      this.get('downloadCSVService').downloadCSV(this.get('sessionService.access_token'), this.get('items'));
-    }
-  }
+  downloadCsvLink: Ember.computed(function() {
+    let content = this.get('downloadCSVService').getCsvBase64(this.get('sessionService.access_token'), this.get('items'));
+
+    var link = "data:text/csv;base64,";
+    link+=content;
+    
+    return link;
+  }),
+
+  downloadCsvFilename: Ember.computed(function() {
+    let current_date = window.moment(new Date()).format('YYYY-MM-DD');
+    let filename = "nanocloud-history-" + current_date;
+    return filename;
+  })
 });

--- a/assets/app/protected/histories/index/template.hbs
+++ b/assets/app/protected/histories/index/template.hbs
@@ -5,7 +5,7 @@
   <p class="color-primary indication">
     History gives you information about your users' sessions. You can also download this table as a CSV file.
     <p class="m-t-1 m-b-0"> 
-      <button class='btn btn-primary downloadcsv' {{ action 'downloadCSV' }}>Save as CSV file</button>
+      <a class='btn btn-primary downloadcsv' href={{downloadCsvLink}} download={{downloadCsvFilename}}>Save as CSV file</a>
       <button {{ action "refreshModel" }} class="btn btn-info">Reload</button> 
     </p>
   </p>


### PR DESCRIPTION
The call to window.location.assign method has been removed because filename cannot be specified. To fix that, we use the html 'download' attribute.
