### PR TITLE
Fix blank page if refresh token is invalid

### DIFF
--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -138,7 +138,10 @@ module.exports = {
                  if (req.body.grant_type === "refresh_token") {
                    var tokenFunction = server.token();
 
-                   return tokenFunction(req, res, function() {
+                   return tokenFunction(req, res, (err) => {
+                     if (err) {
+                       return next(err);
+                     }
                    });
                  }
                  return next();


### PR DESCRIPTION
Add error handler for invalid refresh tokens.
`POST /oauth/token` didn't issue response if the refresh token was not valid.
Now it answers

```
403 Forbidden

{"error":"invalid_grant","error_description":"Invalid refresh token"}
```
