### PR TITLE
Removed storage Netbios ports bindings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,6 @@ services:
     build: ./storage
     image: nanocloud/storage
     ports:
-     - 138/udp:138/udp
-     - 139:139
      - 445/udp:445/udp
      - 445:445
      - 9090:9090

--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get update && \
 
 COPY smb.conf /etc/samba/smb.conf
 
-EXPOSE 138/udp
-EXPOSE 139
 EXPOSE 445
 EXPOSE 445/udp
 EXPOSE 9090


### PR DESCRIPTION
It allows to launch the storage container on a machine that already listens on those ports. They are not needed by Nanocloud.
