### PR TITLE
Limit user access to VDI by AWS credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ AWS driver specific
 - AWS_IMAGE (defaults to ami-09e61366, Nanocloud default image)
 - AWS_FLAVOR (defaults to t2.medium) size of the virtual machine
 - AWS_MACHINE_USERNAME (defaults to Administrator) administrator account on the machine
+- CREDIT_LIMIT (defaults empty string) set a credit limit to users using aws
 
 Openstack driver specific
  - OPENSTACK_USERNAME Openstack username

--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -162,6 +162,9 @@ module.exports = {
               connections.push({
                 id: app.id,
                 hostname: machine.ip,
+                machineId: machine.id,
+                machineType: machine.flavor,
+                machineDriver: machine.type,
                 port: 3389,
                 username: machine.username,
                 password: machine.password,
@@ -175,7 +178,11 @@ module.exports = {
           });
       })
       .catch((err) => {
-        return res.negotiate(err);
+        if (err === 'Exceeded credit') {
+          return res.send(402, err);
+        } else {
+          return res.negotiate(err);
+        }
       });
   }
 };

--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -63,6 +63,12 @@ module.exports = {
       .then((machines) => {
         return res.ok([machines]);
       })
-      .catch((err) => res.negotiate(err));
+      .catch((err) =>  {
+        if (err === 'Exceeded credit') {
+          return res.send(402, err);
+        } else {
+          return res.negotiate(err);
+        }
+      });
   }
 };

--- a/api/drivers/driver.js
+++ b/api/drivers/driver.js
@@ -86,6 +86,16 @@ class Driver {
   createImage(/* image */) {
     return Promise.reject(new Error('Driver\'s method "createImage" not implemented'));
   }
+  /**
+   * Calculate credit used by a user
+   *
+   * @method getUserCredit
+   * @param {Object} User model
+   * @return {Promise[number]}
+   */
+  getUserCredit(/* user */) {
+    return Promise.reject(new Error('Driver\'s method \'getUserCredit\' not implemented'));
+  }
 }
 
 module.exports = Driver;

--- a/api/models/History.js
+++ b/api/models/History.js
@@ -66,6 +66,9 @@ module.exports = {
     },
     machineDriver: {
       type: 'string'
+    },
+    machineType: {
+      type: 'string'
     }
   }
 };

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -64,6 +64,9 @@ module.exports = {
     plazaport: {
       type: 'integer'
     },
+    flavor: {
+      type: 'string'
+    },
     user: {
       model: 'user',
       unique: true

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -39,6 +39,10 @@ module.exports = {
       uuidv4: true,
       defaultsTo: function (){ return uuid.v4(); }
     },
+    credit: {
+      type: 'string',
+      defaultsTo: '0'
+    },
     firstName: {
       type: 'string'
     },

--- a/api/services/UserService.js
+++ b/api/services/UserService.js
@@ -1,0 +1,146 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* global History */
+
+const Promise = require('bluebird');
+const moment = require('moment');
+const _ = require('lodash');
+
+/**
+ * Return time of use of all machines of the user
+ *
+ * @param {object} user The user we need for get the history
+ * @param {object} driver The driver used by the user
+ * @return {Promise[array[object]]}
+ */
+function getUserHistory(user, driver) {
+  const historyQuery = Promise.promisify(History.query);
+  let duration = [];
+  let machines = [];
+
+  return historyQuery({
+    text: 'SELECT "startDate", "endDate", "machineId", "machineType" FROM history WHERE "userId" = $1 AND "machineDriver" = $2 ORDER BY "machineId", "startDate"',
+    values: [user.id, driver]
+  })
+    .then((allHistories) => {
+      var thisMonthStart = new Date(user.createdAt);
+      thisMonthStart.setMonth(thisMonthStart.getMonth() + moment(new Date()).diff(moment(thisMonthStart), 'Month'));
+
+      /**
+       * Concatenate histories if their hours charged times overlap
+       * It assign the current time to the empty endDate properties
+       */
+
+      allHistories = allHistories.rows;
+      allHistories.forEach((element) => {
+        element.startDate = new Date (element.startDate);
+
+        /**
+         * If the history start date is not on the actual month,
+         * it doesn't take count of it
+         */
+
+        if (element.startDate >= thisMonthStart) {
+          if (!element.endDate || element.endDate === '') {
+            element.endDate = new Date();
+          } else {
+            element.endDate = new Date(element.endDate);
+          }
+          var listedMachines = machines.filter((machine) => {
+            return machine.id === element.machineId;
+          });
+
+          /**
+           * If the machine alreadly exist on machines array, we calculate
+           * if the current history startDate overlap with one of the previous
+           * history of this machine.
+           */
+
+          if (listedMachines.length === 0) {
+            machines.push({
+              id: element.machineId,
+              type: element.machineType,
+              start: [element.startDate],
+              end: [element.endDate]
+            });
+          } else {
+
+            /**
+             * If no history overlaps with the current history, it pushes it to the
+             * machine history array.
+             */
+
+            if (!_.some(listedMachines[0].start, (start, index) => {
+              var diff = moment(listedMachines[0].end[index]).diff(moment(start), 'hours');
+              if ((moment(listedMachines[0].end[index]).diff(moment(start), 'second') % 3600) !== 0) {
+                diff += 1;
+              }
+              if (element.startDate < start.setHours(start.getHours() + diff)) {
+                start.setHours(start.getHours() - diff);
+                if (element.endDate > listedMachines[0].end[index]) {
+                  listedMachines[0].end[index] = element.endDate;
+                }
+                return true;
+              }
+              start.setHours(start.getHours() - diff);
+              return false;
+            })) {
+              listedMachines[0].start.push(element.startDate);
+              listedMachines[0].end.push(element.endDate);
+            }
+          }
+        }
+      });
+    })
+    .then(() => {
+
+      /**
+       * Calcul the total hours used for all machines
+       */
+
+      machines.forEach((element) => {
+        var totalDiff = 0;
+        element.start.forEach((el, index) => {
+          var start = moment(el);
+          var end = moment(element.end[index]);
+          totalDiff = totalDiff + end.diff(start, 'hours');
+          if ((end.diff(start, 'second') % 3600) !== 0) {
+            totalDiff += 1;
+          }
+        });
+
+        duration.push({
+          type: element.type,
+          time: totalDiff
+        });
+      });
+    })
+    .then(() => {
+      return duration;
+    });
+}
+
+module.exports = {
+  getUserHistory
+};

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -44,7 +44,9 @@ export default Ember.Service.extend({
     'favIconPath',
     'logoPath',
     'primaryColor',
-    'uploadLimit'
+    'uploadLimit',
+    'creditLimit',
+    'iaas'
   ],
   keyToBeRetrievedAsString: Ember.computed('keyToBeRetrieved', function() {
     let params = this.get('keyToBeRetrieved');

--- a/assets/app/protected/configs/user-right/controller.js
+++ b/assets/app/protected/configs/user-right/controller.js
@@ -26,6 +26,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   configController: Ember.inject.controller('protected.configs'),
   defaultGroup: Ember.computed.alias('configController.defaultGroup'),
+  isAws: Ember.computed.equal('configController.iaas', 'aws'),
   actions: {
     selectGroup(id) {
       this.get('configController').send('selectGroup', id);

--- a/assets/app/protected/configs/user-right/template.hbs
+++ b/assets/app/protected/configs/user-right/template.hbs
@@ -43,4 +43,11 @@
   {{input type="checkbox" checked=configController.autoLogoff}}
   <label for="cbox2">Logoff after closing VDI</label>
 </div>
-
+{{#if isAws}}
+  <div class="form-group row">
+    <div class="col-sm-2">
+      <p class="confirm-input-item color-primary">Set a credit limit to users using AWS:</p>
+    </div>
+    <div class="col-sm-2">{{input-confirm type="string" value=configController.creditLimit}}</div>
+  </div>
+{{/if}}

--- a/assets/app/protected/histories/index/controller.js
+++ b/assets/app/protected/histories/index/controller.js
@@ -72,7 +72,7 @@ export default Ember.Controller.extend({
         application: item.get('connectionId'),
         machineDriver: item.get('machineDriver'),
         machineId: item.get('machineId'),
-        machineSize: item.get('machineSize'),
+        machineSize: item.get('machineType'),
         start: window.moment(item.get('startDate')).format('MMMM Do YYYY, h:mm:ss A'),
         end: window.moment(item.get('endDate')).format('MMMM Do YYYY, h:mm:ss A'),
         isActive: item.get('isActive'),

--- a/assets/app/protected/users/user/controller.js
+++ b/assets/app/protected/users/user/controller.js
@@ -28,6 +28,8 @@ export default Ember.Controller.extend({
 
   store: Ember.inject.service('store'),
   session: Ember.inject.service('session'),
+  configController: Ember.inject.controller('protected.configs'),
+  isAws: Ember.computed.equal('configController.iaas', 'aws'),
   passwordConfirmation: null,
   isMe: Ember.computed('session.user', 'model', function() {
     return this.get('model.id') === this.get('session.user.id');

--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -109,7 +109,19 @@
               {{moment-calendar model.expirationDateInMs}}
             {{/if}}
           </td>
-        </tr>
+		</tr>
+    {{#if isAws}}
+      <tr>
+          <th scope="row">Credit Used</th>
+          <td>
+            {{#if model.credit}}
+              {{model.credit}}
+            {{else}}
+              No credit used
+            {{/if}}
+          </td>
+      </tr>
+    {{/if}}
         <tr>
           <th scope="row">Creation date</th>
           <td>

--- a/assets/app/user/model.js
+++ b/assets/app/user/model.js
@@ -83,6 +83,7 @@ export default DS.Model.extend(Validations, {
   password: DS.attr('string'),
   createdAt: DS.attr('string'),
   expirationDate: DS.attr('number'),
+  credit: DS.attr('string'),
 
   expirationDateInMs: Ember.computed('expirationDate', function() {
     return this.get('expirationDate') * 1000;

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -64,6 +64,7 @@ module.exports = {
     autoLogoff: false,
     defaultGroup: '',
     awsCache: 0,
+    creditLimit: '',
 
     iaas: 'manual',
     machinePoolSize: 1,

--- a/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
+++ b/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
@@ -81,6 +81,7 @@ public class LoggedConnection extends SimpleConnection {
       String machineId = data.getString("id");
       dataAttribute = data.getJSONObject("attributes");
       String machineDriver = dataAttribute.getString("type");
+      String flavor = dataAttribute.getString("flavor");
 
       URL myUrl = new URL("http://" + hostname + ":" + port + "/" + endpoint);
       HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
@@ -99,7 +100,9 @@ public class LoggedConnection extends SimpleConnection {
               .add("connection-id", connection.getConnectionName())
               .add("start-date", connection.getStartDate().toString())
               .add("end-date", "")
-              .add("machine-id", machineId)))
+              .add("machine-id", machineId)
+              .add("machine-driver", machineDriver)
+              .add("machine-type", flavor)))
         .build();
 
       urlConn.setUseCaches(false);
@@ -202,6 +205,7 @@ public class LoggedConnection extends SimpleConnection {
         String machineId = data.getString("id");
         JSONObject dataAttribute = data.getJSONObject("attributes");
         String machineDriver = dataAttribute.getString("type");
+        String flavor = dataAttribute.getString("flavor");
 
         URL myUrl = new URL("http://" + hostname + ":" + port + "/" + endpoint + "/" + LoggedConnection.this.historyId);
         HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
@@ -219,7 +223,9 @@ public class LoggedConnection extends SimpleConnection {
                 .add("connection-id", this.connection.getConnectionName())
                 .add("start-date", this.connection.getStartDate().toString())
                 .add("end-date", new Date().toString())
-                .add("machine-id", machineId)))
+                .add("machine-id", machineId)
+                .add("machine-driver", machineDriver)
+                .add("machine-type", flavor)))
           .build();
 
         urlConn.setUseCaches(false);

--- a/tests/api/apps.test.js
+++ b/tests/api/apps.test.js
@@ -464,103 +464,127 @@ module.exports = function() {
 
     it('Admins should be able to get connection out of every app', function(done) {
 
-      nano.request(sails.hooks.http.app)
-        .get('/api/apps/connections')
-        .set(nano.adminLogin())
-        .expect(200)
-        .expect((res) => {
-          expect(res.body.data).to.have.length(3);
-        })
-        .expect((res) => {
+      MachineService.getMachineForUser({
+        id: nano.adminId()
+      })
+        .then((machine) => {
+          nano.request(sails.hooks.http.app)
+            .get('/api/apps/connections')
+            .set(nano.adminLogin())
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.data).to.have.length(3);
+            })
+            .expect((res) => {
+              expect(res.body.data).to.include({
+                'type': 'apps',
+                'id': app1,
+                'attributes': {
+                  'hostname': '127.0.0.1',
+                  'port': 3389,
+                  'username': 'Administrator',
+                  'password': null,
+                  'remote-app': '',
+                  'protocol': 'rdp',
+                  'app-name': 'app1',
+                  'machine-id': machine.id,
+                  'machine-type': null,
+                  'machine-driver':null
+                }
+              });
+              expect(res.body.data).to.include({
+                'type': 'apps',
+                'id': app2,
+                'attributes': {
+                  'hostname': '127.0.0.1',
+                  'port': 3389,
+                  'username': 'Administrator',
+                  'password': null,
+                  'remote-app': '',
+                  'protocol': 'rdp',
+                  'app-name': 'app2',
+                  'machine-id': machine.id,
+                  'machine-type': null,
+                  'machine-driver':null
+                }
+              });
+              expect(res.body.data).to.include({
+                'type': 'apps',
+                'id': nano.desktopId(),
+                'attributes': {
+                  'hostname': '127.0.0.1',
+                  'port': 3389,
+                  'username': 'Administrator',
+                  'password': null,
+                  'remote-app': '',
+                  'protocol': 'rdp',
+                  'app-name': 'Desktop',
+                  'machine-id': machine.id,
+                  'machine-type': null,
+                  'machine-driver':null
+                }
+              });
 
-          expect(res.body.data).to.include({
-            'type': 'apps',
-            'id': app1,
-            'attributes': {
-              'hostname': '127.0.0.1',
-              'port': 3389,
-              'username': 'Administrator',
-              'password': null,
-              'remote-app': '',
-              'protocol': 'rdp',
-              'app-name': 'app1'
-            }
-          });
-          expect(res.body.data).to.include({
-            'type': 'apps',
-            'id': app2,
-            'attributes': {
-              'hostname': '127.0.0.1',
-              'port': 3389,
-              'username': 'Administrator',
-              'password': null,
-              'remote-app': '',
-              'protocol': 'rdp',
-              'app-name': 'app2'
-            }
-          });
-          expect(res.body.data).to.include({
-            'type': 'apps',
-            'id': nano.desktopId(),
-            'attributes': {
-              'hostname': '127.0.0.1',
-              'port': 3389,
-              'username': 'Administrator',
-              'password': null,
-              'remote-app': '',
-              'protocol': 'rdp',
-              'app-name': 'Desktop'
-            }
-          });
-
-        })
-        .then(() => {
-          return done();
+            })
+            .then(() => {
+              return done();
+            });
         });
     });
 
     it('Regular users should be able to get connections out of their apps', function(done) {
 
-      nano.request(sails.hooks.http.app)
-        .get('/api/apps/connections')
-        .set({
-          'Authorization': 'Bearer ' + someguytoken
-        })
-        .expect(200)
-        .expect((res) => {
-          expect(res.body.data).to.have.length(2);
-        })
-        .expect((res) => {
+      MachineService.getMachineForUser({
+        id: someguy
+      })
+        .then((machine) => {
+          nano.request(sails.hooks.http.app)
+            .get('/api/apps/connections')
+            .set({
+              'Authorization': 'Bearer ' + someguytoken
+            })
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.data).to.have.length(2);
+            })
+            .expect((res) => {
 
-          expect(res.body.data).to.include({
-            'type': 'apps',
-            'id': app1,
-            'attributes': {
-              'hostname': '127.0.0.1',
-              'port': 3389,
-              'username': 'Administrator',
-              'password': null,
-              'remote-app': '',
-              'protocol': 'rdp',
-              'app-name': 'app1'
-            }
-          });
-          expect(res.body.data).to.include({
-            'type': 'apps',
-            'id': app2,
-            'attributes': {
-              'hostname': '127.0.0.1',
-              'port': 3389,
-              'username': 'Administrator',
-              'password': null,
-              'remote-app': '',
-              'protocol': 'rdp',
-              'app-name': 'app2'
-            }
-          });
-        })
-        .then(() => {
-          return done();
+              expect(res.body.data).to.include({
+                'type': 'apps',
+                'id': app1,
+                'attributes': {
+                  'hostname': '127.0.0.1',
+                  'port': 3389,
+                  'username': 'Administrator',
+                  'password': null,
+                  'remote-app': '',
+                  'protocol': 'rdp',
+                  'app-name': 'app1',
+                  'machine-id': machine.id,
+                  'machine-type': null,
+                  'machine-driver':null
+                }
+              });
+              expect(res.body.data).to.include({
+                'type': 'apps',
+                'id': app2,
+                'attributes': {
+                  'hostname': '127.0.0.1',
+                  'port': 3389,
+                  'username': 'Administrator',
+                  'password': null,
+                  'remote-app': '',
+                  'protocol': 'rdp',
+                  'app-name': 'app2',
+                  'machine-id': machine.id,
+                  'machine-type': null,
+                  'machine-driver':null
+                }
+              });
+            })
+            .then(() => {
+              return done();
+            });
         });
     });
   });

--- a/tests/unit/drivers/driver.test.js
+++ b/tests/unit/drivers/driver.test.js
@@ -1,0 +1,163 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* global History */
+
+const DummyDriver = require('../../../api/drivers/dummy/driver');
+let _driver = null;
+
+process.env.iaas = 'dummy';
+process.env.machinePoolSize = 3;
+process.env.sessionDuration = 0;
+
+describe('Dummy driver', () => {
+  describe('getUserCredit', () => {
+    before('clean history database', function(done) {
+      History.query('TRUNCATE TABLE public.history', () => {
+          _driver = new (DummyDriver)();
+          _driver.initialize();
+          done();
+      });
+    });
+
+    it('Should return 0', (done) => {
+      _driver.getUserCredit({
+        id : 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        createdAt: '2016-06-20 10:00:00+00'
+      }, 'aws')
+        .then((price) => {
+          if (price !== 0) {
+            return done(new Error('Bad price returned'));
+          } else {
+            done();
+          }
+        });
+    });
+
+    it('Should return a coherent price', (done) => {
+      var start = new Date();
+      var end = new Date();
+      start.setHours(0);
+      start.setMinutes(5);
+      end.setHours(1);
+      end.setMinutes(0);
+      History.create({
+        userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        connectionId: 'Desktop',
+        startDate: start.toString(),
+        endDate: end.toString(),
+        createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+        updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+        machineId: 'f5362974-a8df-4ed6-89f5-99093b145999',
+        machineDriver: 'aws',
+        machineType: 't2.small'
+      })
+        .then(() => {
+          return _driver.getUserCredit({
+            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+            createdAt: '2016-06-20 10:00:00+00'
+          }, 'aws');
+        })
+        .then((price) => {
+          if (price !== 0.04) {
+            return done(new Error('Bad price returned'));
+          } else {
+            done();
+          }
+        });
+    });
+
+    it('Should return a coherent price', (done) => {
+      var start = new Date();
+      var start2 = new Date();
+      var start3 = new Date();
+      var end = new Date();
+      var end2 = new Date();
+      var end3 = new Date();
+
+      start.setHours(0);
+      start2.setHours(2);
+      start3.setHours(5);
+      start.setMinutes(5);
+      start2.setMinutes(5);
+      start3.setMinutes(5);
+      end.setHours(1);
+      end2.setHours(4);
+      end3.setHours(8);
+      end.setMinutes(0);
+      end2.setMinutes(0);
+      end3.setMinutes(0);
+
+      History.create([{
+        userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        connectionId: 'Desktop',
+        startDate: start.toString(),
+        endDate: end.toString(),
+        createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+        updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+        machineId: 'f5362974-a8df-4ed6-89f5-99093b145999',
+        machineDriver: 'aws',
+        machineType: 't2.small'
+      },
+      {
+        userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        connectionId: 'Desktop',
+        startDate: start2.toString(),
+        endDate: end2.toString(),
+        createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+        updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+        machineId: 'f5362974-o6er-4ed6-89f5-99093b145999',
+        machineDriver: 'aws',
+        machineType: 't2.small'
+      },
+      {
+        userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        connectionId: 'Desktop',
+        startDate: start3.toString(),
+        endDate: end3.toString(),
+        createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+        updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+        machineId: 'f5362974-o6er-4ed6-89f5-99093b145999',
+        machineDriver: 'aws',
+        machineType: 't2.small'
+      }])
+        .then(() => {
+          return _driver.getUserCredit({
+            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+            createdAt: '2016-06-20 10:00:00+00'
+          }, 'aws');
+        })
+        .then((price) => {
+          if (price !== (6 * 0.04)) {
+            return done(new Error('Bad price returned'));
+          } else {
+            done();
+          }
+        })
+        .catch((err) => {
+          return done(new Error(err));
+        });
+    });
+  });
+});

--- a/tests/unit/drivers/fakePrice.json
+++ b/tests/unit/drivers/fakePrice.json
@@ -1,0 +1,54 @@
+{
+  "products" : {
+    "SUPPEZST6XFGKCM2" : {
+      "sku" : "SUPPEZST6XFGKCM2",
+      "productFamily" : "Compute Instance",
+      "attributes" : {
+        "servicecode" : "AmazonEC2",
+        "location" : "EU (Frankfurt)",
+        "locationType" : "AWS Region",
+        "instanceType" : "t2.small",
+        "instanceFamily" : "General purpose",
+        "vcpu" : "1",
+        "physicalProcessor" : "Intel Xeon Family",
+        "clockSpeed" : "Up to 3.3 GHz",
+        "memory" : "2 GiB",
+        "storage" : "EBS only",
+        "networkPerformance" : "Low to Moderate",
+        "processorArchitecture" : "32-bit or 64-bit",
+        "tenancy" : "Shared",
+        "operatingSystem" : "Windows",
+        "licenseModel" : "License Included",
+        "usagetype" : "EUC1-BoxUsage:t2.small",
+        "operation" : "RunInstances:0002",
+        "preInstalledSw" : "NA",
+        "processorFeatures" : "Intel AVX; Intel Turbo"
+      }
+    }
+  },
+  "terms" : {
+    "OnDemand" : {
+      "SUPPEZST6XFGKCM2" : {
+        "SUPPEZST6XFGKCM2.JRTCKXETXF" : {
+          "offerTermCode" : "JRTCKXETXF",
+          "sku" : "SUPPEZST6XFGKCM2",
+          "effectiveDate" : "2016-06-01T00:00:00Z",
+          "priceDimensions" : {
+            "SUPPEZST6XFGKCM2.JRTCKXETXF.6YS6EN2CT7" : {
+              "rateCode" : "SUPPEZST6XFGKCM2.JRTCKXETXF.6YS6EN2CT7",
+              "description" : "$0.04 per On Demand Windows t2.small Instance Hour",
+              "beginRange" : "0",
+              "endRange" : "Inf",
+              "unit" : "Hrs",
+              "pricePerUnit" : {
+                "USD" : "0.0400000000"
+              },
+              "appliesTo" : [ ]
+            }
+          },
+          "termAttributes" : { }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/services/UserService.test.js
+++ b/tests/unit/services/UserService.test.js
@@ -1,0 +1,230 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+// jshint mocha:true
+
+/* global UserService, History */
+
+describe('User Service', () => {
+  describe('getUserHistory', () => {
+    before('Clean History database', function(done) {
+      History.query('TRUNCATE TABLE public.history', done);
+    });
+
+    it('Should return an empty array', (done) => {
+      UserService.getUserHistory({
+          id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+          createdAt: '2016-06-20 10:00:00+00'
+      }, 'aws')
+        .then((his) => {
+          if (his.length !== 0) {
+            return done(new Error('History should be empty'));
+          } else {
+            this.newDate = new Date();
+            this.newDate.setHours(0);
+            this.newDate.setMinutes(5);
+            History.create([{
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: this.newDate.toString(),
+              endDate: '',
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'g5362974-a8df-4ed6-89f5-99093b145999',
+              machineDriver: 'aws',
+              machineType: 't2.medium'
+            },
+            {
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: 'Wed Jun 27 14:08:05 UTC 2016',
+              endDate: '',
+              createdAt: 'Wed Jun 20 10:00:00 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'g5362974-a8df-4ed6-89f5-99093b145999',
+              machineDriver: 'aws',
+              machineType: 't2.medium'
+            }], done);
+          }
+        });
+    });
+
+    it('Should return a valid timer', (done) => {
+      UserService.getUserHistory({
+        id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        createdAt: '2016-06-20 10:00:00+00'
+      }, 'aws')
+        .then((his) => {
+          if (his.length !== 1) {
+            return done(new Error('It should found an history'));
+          } else if (!his[0].time) {
+            return done(new Error('Bad time returned'));
+          } else {
+            History.destroy({
+              machineId: 'g5362974-a8df-4ed6-89f5-99093b145999'
+            })
+              .then(() => {
+                var end = new Date();
+                end.setHours(1);
+                end.setMinutes(0);
+                History.create({
+                  userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                  connectionId: 'Desktop',
+                  startDate: this.newDate.toString(),
+                  endDate: end.toString(),
+                  createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+                  updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+                  machineId: 'f5362974-a8df-4ed6-89f5-99093b145999',
+                  machineDriver: 'aws',
+                  machineType: 't2.medium'
+                }, done);
+              });
+          }
+        });
+    });
+
+    it('Should return correct history timer', (done) => {
+      return UserService.getUserHistory({
+        id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        createdAt: '2016-06-20 10:00:00+00'
+      }, 'aws')
+        .then((his) => {
+          if (his.length !== 1) {
+            return done(new Error('It should found an history'));
+          } else if (his[0].type !== 't2.medium') {
+            return done(new Error('Bad type returned'));
+          } else if (his[0].time !== 1) {
+            return done(new Error('Bad time returned'));
+          } else {
+            var end = new Date();
+            end.setHours(1);
+            end.setMinutes(0);
+            return History.create({
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: this.newDate.toString(),
+              endDate: end.toString(),
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'f5862974-g8df-4ed6-89f5-99093b145996',
+              machineDriver: 'aws',
+              machineType: 't2.small'
+            });
+          }
+        })
+        .then(() => {
+          return UserService.getUserHistory({
+            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+            createdAt: '2016-06-20 10:00:00+00'
+          }, 'aws');
+        })
+        .then((his) => {
+          if (his.length !== 2) {
+            return done(new Error('Bad number of machine history returned'));
+          } else if (his[1].time !== 1) {
+            return done(new Error('Bad timer returned for the second machine'));
+          } else if (his[1].type !== 't2.small') {
+            return done(new Error('Bad type returned'));
+          } else {
+            var start2 = new Date();
+            var start3 = new Date();
+            var end = new Date();
+            var end2 = new Date();
+            var end3 = new Date();
+
+            start2.setHours(2);
+            start2.setMinutes(5);
+            start3.setHours(5);
+            start3.setMinutes(5);
+            end.setHours(1);
+            end.setMinutes(0);
+            end2.setHours(4);
+            end2.setMinutes(0);
+            end3.setHours(8);
+            end3.setMinutes(0);
+
+            return History.create([{
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: this.newDate.toString(),
+              endDate: end.toString(),
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'f5862974-g8df-4ed6-89f5-99093b145996',
+              machineDriver: 'aws',
+              machineType: 't2.small'
+            },
+            {
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: start2.toString(),
+              endDate: end2.toString(),
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'f5862974-g8df-4ed6-89f5-99093b145996',
+              machineDriver: 'aws',
+              machineType: 't2.small'
+            },
+            {
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: start3.toString(),
+              endDate: end3.toString(),
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'f5862974-g8df-4ed6-89f5-99093b145996',
+              machineDriver: 'aws',
+              machineType: 't2.small'
+            },
+            {
+              userId: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+              connectionId: 'Desktop',
+              startDate: this.newDate.toString(),
+              endDate: end.toString(),
+              createdAt: 'Wed Jul 27 14:07:15 UTC 2016',
+              updatedDate: 'Wed Jul 27 14:53:15 UTC 2016',
+              machineId: 'f5362974-a8df-4ed6-89f5-99093b145999',
+              machineDriver: 'aws',
+              machineType: 't2.medium'
+            }]);
+          }
+        })
+        .then(() => {
+          return UserService.getUserHistory({
+            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+            createdAt: '2016-06-20 10:00:00+00'
+          }, 'aws');
+        })
+        .then((his) => {
+          if (his.length !== 2) {
+            return done(new Error('Bad number of machine history returned'));
+          } else if (his[0].time !== 1 || his[1].time !== 6) {
+            return done(new Error('Bad timer returned'));
+          } else {
+            done();
+          }
+        });
+    });
+  });
+});


### PR DESCRIPTION
Add An aws credit limit, 

Add getUserHistory for searching the time use of all machines of a user.
Add getUserCredit using getUserHistory for calculate the global credit used by a user.
Backend return a 402 error if the user exceeded his credit limit when trying to opening a vm.
It's possible to set this limit in Configuration.
