### PR TITLE
FIX Manual driver duplicate machine if run multiple times

### DIFF
--- a/api/drivers/manual/driver.js
+++ b/api/drivers/manual/driver.js
@@ -42,7 +42,7 @@ class ManualDriver extends Driver {
       .then((config) => {
 
         let machines = config.machines.map((machine) => {
-          return Machine.create(machine);
+          return Machine.findOrCreate(machine);
         });
 
         return Promise.all(machines);


### PR DESCRIPTION
In response of issue #54 

Change create with findOrCreate, for used the machines already in base
when run multiple times.
