### PR TITLE
Protect destroy endpoint to prevent history deleting.

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -61,4 +61,8 @@ module.exports.policies = {
     update: true,
     findOne: true,
   },
+
+  HistoryController : {
+    destroy: false
+  },
 };

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -33,6 +33,7 @@ const testUserLimitation = require('./user-limitation.test');
 const testConfig = require('./config.test');
 const testGroup = require('./group.test');
 const testApps = require('./apps.test');
+const testSecurity = require('./security.test');
 
 var request = require('supertest');
 
@@ -55,3 +56,4 @@ testUserLimitation();
 testConfig();
 testGroup();
 testApps();
+testSecurity();

--- a/tests/api/security.test.js
+++ b/tests/api/security.test.js
@@ -1,0 +1,44 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* globals sails*/
+
+const nano = require('./lib/nanotest');
+
+module.exports = function() {
+
+  describe('Security', function() {
+
+    describe('Delete history', function() {
+
+      it('Should not delete history', function(done) {
+        nano.request(sails.hooks.http.app)
+          .delete('/api/histories')
+          .set(nano.adminLogin())
+          .expect(403)
+          .end(done);
+      });
+    });
+  });
+};


### PR DESCRIPTION
In response to issue #40 

Delete request to `/api/histories` now return forbidden (403)
Default `destroy` function from `HistoryController` are now disable.

Add a security test file.
