### PR TITLE
Bugfix: In Dashboard page, machines up count is always 0

### DIFF
--- a/assets/app/protected/dashboard/controller.js
+++ b/assets/app/protected/dashboard/controller.js
@@ -52,7 +52,7 @@ export default Ember.Controller.extend({
 
   machines: Ember.computed('model.machines', 'model.machines', function() {
     var machines = this.get('model.machines')
-      .filterBy('status', 'up');
+      .filterBy('status', 'RUNNING');
     return machines;
   }),
 


### PR DESCRIPTION
Fixed #52 .
The front-end did not handle the new status code returned by the API.
status 'up' has been replaced by 'RUNNING'
