### PR TITLE
Display machine.id in machines table at /machines

### DIFF
--- a/assets/app/protected/machines/index/controller.js
+++ b/assets/app/protected/machines/index/controller.js
@@ -68,6 +68,11 @@ export default Ember.Controller.extend({
 
   columns: [
     {
+      propertyName: 'id',
+      title: 'ID',
+      disableFiltering: true,
+    },
+    {
       propertyName: 'name',
       title: 'Name',
       disableFiltering: true,


### PR DESCRIPTION
Fixes #51 
Column 'id' has been added to machine list table
