### PR TITLE
Bugfix: User's "creation date" always equals current date

### DIFF
--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -110,7 +110,7 @@
         <tr>
           <th scope="row">Creation date</th>
           <td>
-            {{moment-calendar model.signupDate}}
+            {{moment-calendar model.createdAt}}
           </td>
         </tr>
 				{{#if session.user.isAdmin }}

--- a/assets/app/user/model.js
+++ b/assets/app/user/model.js
@@ -81,7 +81,7 @@ export default DS.Model.extend(Validations, {
   firstName: DS.attr('string'),
   lastName: DS.attr('string'),
   password: DS.attr('string'),
-  signupDate: DS.attr('number'),
+  createdAt: DS.attr('date'),
   expirationDate: DS.attr('number'),
 
   expirationDateInMs: Ember.computed('expirationDate', function() {


### PR DESCRIPTION
Bugfix: #33 
The user model now expect 'createdAt' property instead of 'signupDate'
