### PR TITLE
Mount user storage on session start

### DIFF
--- a/api/models/Storage.js
+++ b/api/models/Storage.js
@@ -57,7 +57,20 @@ module.exports = {
                   '--create-home',
                   '--groups',
                   'users'
-                 ]
+                 ],
+        wait: true
+      })
+      .then(() => {
+        return PlazaService.exec(
+          values.hostname,
+          values.port, {
+            command: ['smbpasswd',
+                      '-a',
+                      values.username
+                     ],
+            stdin: values.password + '\n' + values.password,
+            wait: true
+          });
       })
       .then(() => {
         return next();

--- a/api/services/PlazaService.js
+++ b/api/services/PlazaService.js
@@ -40,7 +40,8 @@ module.exports = {
    * {
    *   username: '', // User's name the command should be executed by
    *   wait: true || false, // whether the call should be blocking or not
-   *   command: array(). // array of strings to execute
+   *   hideWindow: true || false, // whether the application should be run in background or not
+   *   command: array(). // argument list to execute. Behaves like argv
    * }
    * @return {Promise} Request to Plaza
    */

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -22,7 +22,10 @@
     ],
     "quotes": [
       "error",
-      "single"
+      "single",
+      {
+          "allowTemplateLiterals": true
+      }
     ],
     "semi": [
       "error",

--- a/tests/api/apps.test.js
+++ b/tests/api/apps.test.js
@@ -29,13 +29,14 @@ var nano = require('./lib/nanotest');
 var chai = require('chai');
 var expect = chai.expect;
 var http = require('http');
+const Promise = require('bluebird');
 
 module.exports = function() {
   describe('Plaza app launch', function() {
 
     let fakePlaza = null;
     let appId = '9282fd13-5df0-4cf6-a101-ae507f75ab47';
-    let appOpened = false; // Use by fake plaza to hold application status
+    let appOpened = []; // Use by fake plaza to hold application status
     let originalFakePlazaPort = null;
 
     const expectedSchema = {
@@ -65,7 +66,7 @@ module.exports = function() {
           body = Buffer.concat(body).toString();
 
           if (req.url === '/exec') {
-            appOpened = JSON.parse(body);
+            appOpened.push(JSON.parse(body));
             res.end();
           }
 
@@ -139,11 +140,17 @@ module.exports = function() {
         .expect(200)
         .expect(nano.jsonApiSchema(expectedSchema))
         .then(() => {
-          expect(appOpened).to.deep.equal({
-            command: [
-                'C:\\fake.exe'
-            ],
-            username: 'Administrator'
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              expect(appOpened).to.deep.include({
+                command: [
+                  'C:\\fake.exe'
+                ],
+                username: 'Administrator'
+              });
+
+              return resolve();
+            }, 10);
           });
         })
         .then(() => {


### PR DESCRIPTION
Automatically mount user storage when opening user's session.
The storage will be renamed "Storage".

When the storage is already mounted, an error is fired. We can't know for sure if there is an error with Plaza itself or if this is just net.exe saying that the storage is already mounted. So "errors" are caught and  silently ignored.
