### PR TITLE
nodemailer-stub-transport 1.1.0 introduced a bug falling back to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.14.0",
     "moment": "^2.13.0",
     "nodemailer": "^2.5.0",
-    "nodemailer-stub-transport": "^1.0.0",
+    "nodemailer-stub-transport": "1.0.0",
     "oauth2orize": "^1.3.0",
     "passport": "^0.3.2",
     "passport-http": "^0.3.0",


### PR DESCRIPTION
The following error occured after `nodemailer-stub-transport` upgraded itself to version 1.1.0:

```
TypeError: Cannot read property 'then' of undefined
at ConfigService.get.then (/home/travis/build/Nanocloud/nanocloud/api/services/EmailService.js:62:11)
at tryCatcher (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/util.js:16:23)
at Promise._settlePromiseFromHandler (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/promise.js:504:31)
at Promise._settlePromise (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/promise.js:561:18)
at Promise._settlePromise0 (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/promise.js:606:10)
at Promise._settlePromises (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/promise.js:685:18)
at Async._drainQueue (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/async.js:138:16)
at Async._drainQueues (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/async.js:148:10)
at Immediate.Async.drainQueues (/home/travis/build/Nanocloud/nanocloud/node_modules/bluebird/js/release/async.js:17:14)
at runCallback (timers.js:574:20)
at tryOnImmediate (timers.js:554:5)
at processImmediate [as _immediateCallback] (timers.js:533:5)
```

Falling back and forcing version 1.0.0
