### PR TITLE
Check upload limit before uploading a file.

### DIFF
--- a/api/controllers/StorageController.js
+++ b/api/controllers/StorageController.js
@@ -98,13 +98,22 @@ module.exports = {
     } else {
       getFiles = StorageService.findOrCreate(req.user)
         .then((storage) => {
-          return PlazaService.files(storage, '/home/' + storage.username);
+          return PlazaService.files(storage, '/home/' + storage.username)
+            .then((files) => {
+              return StorageService.storageSize(storage)
+                .then((size) => {
+                  files.meta = {
+                    storageSize: size
+                  };
+                  return files;
+                });
+            });
         });
     }
-
     getFiles.then((files) => {
       return res.send(files);
-    });
+    })
+      .catch(res.negotiate);
   },
 
   /**

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -43,7 +43,8 @@ export default Ember.Service.extend({
     'title',
     'favIconPath',
     'logoPath',
-    'primaryColor'
+    'primaryColor',
+    'uploadLimit'
   ],
   keyToBeRetrievedAsString: Ember.computed('keyToBeRetrieved', function() {
     let params = this.get('keyToBeRetrieved');


### PR DESCRIPTION
Fixes #55 
`storageSize` use now the `du` command and return the size of the user storage in KB.
The storageSize is returned in the response of `api/files` in meta in KB.
Unit test is updated and check if storageSize take files in directories into account.

Now the upload limit is checked in front before the file is uploaded. If you are over the limit the error message is immediately display and upload endpoint is not called.
`uploadLimit` is available from configuration service.
