### PR TITLE
Fix broker never scaled down

### DIFF
--- a/api/controllers/HistoryController.js
+++ b/api/controllers/HistoryController.js
@@ -31,12 +31,20 @@ module.exports = {
   create(req, res) {
     req.body = JsonApiService.deserialize(req.body);
 
-    if (req.body.data.attributes['end-date'] === '') {
+    if (req.body.data.attributes.endDate === '') {
       MachineService.sessionOpen(req.user);
-    } else {
-      MachineService.sessionEnded(req.user);
     }
 
     return JsonApiService.createRecord(req, res);
+  },
+
+  update(req, res) {
+    req.body = JsonApiService.deserialize(req.body);
+
+    if (req.body.data.attributes.endDate !== '') {
+      MachineService.sessionEnded(req.user);
+    }
+
+    return JsonApiService.updateOneRecord(req, res);
   }
 };

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -47,7 +47,7 @@ class DummyDriver extends BaseDriver {
     var FakePlaza = http.createServer((req, res) => {
       res.writeHead(200, {'Content-Type': 'application/json'});
 
-      if (req.url === '/sessions/') {
+      if (req.url === '/sessions/Administrator') {
 
         let status = (_sessionOpen === true) ? 'Active' : 'Inactive';
         let data = {
@@ -105,6 +105,7 @@ class DummyDriver extends BaseDriver {
     machine.id = id;
     machine.name = options.name;
     machine.ip = _plazaAddress;
+    machine.username = 'Administrator';
     machine.plazaport = _plazaPort;
 
     this._machines[machine.id] = machine;

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -85,7 +85,7 @@ module.exports = {
         protocol: 'http',
         hostname: this.ip,
         port: this.plazaport,
-        pathname: '/sessions/'
+        pathname: '/sessions/' + this.username
       });
 
       return request.getAsync(plazaAddr).then((res) => {

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -161,10 +161,8 @@ function getMachineForUser(user) {
                 }
 
                 if (res.rows.length) {
-                  return _updateMachinesPool()
-                    .then(() => {
-                      return resolve(res.rows[0]);
-                    });
+                  _updateMachinesPool();
+                  return resolve(res.rows[0]);
                 }
 
                 return reject(noMachineFoundError);

--- a/tests/api/apps.test.js
+++ b/tests/api/apps.test.js
@@ -143,7 +143,7 @@ module.exports = function() {
             command: [
                 'C:\\fake.exe'
             ],
-            username: null
+            username: 'Administrator'
           });
         })
         .then(() => {
@@ -472,7 +472,7 @@ module.exports = function() {
             'attributes': {
               'hostname': '127.0.0.1',
               'port': 3389,
-              'username': null,
+              'username': 'Administrator',
               'password': null,
               'remote-app': '',
               'protocol': 'rdp',
@@ -485,7 +485,7 @@ module.exports = function() {
             'attributes': {
               'hostname': '127.0.0.1',
               'port': 3389,
-              'username': null,
+              'username': 'Administrator',
               'password': null,
               'remote-app': '',
               'protocol': 'rdp',
@@ -498,7 +498,7 @@ module.exports = function() {
             'attributes': {
               'hostname': '127.0.0.1',
               'port': 3389,
-              'username': null,
+              'username': 'Administrator',
               'password': null,
               'remote-app': '',
               'protocol': 'rdp',
@@ -531,7 +531,7 @@ module.exports = function() {
             'attributes': {
               'hostname': '127.0.0.1',
               'port': 3389,
-              'username': null,
+              'username': 'Administrator',
               'password': null,
               'remote-app': '',
               'protocol': 'rdp',
@@ -544,7 +544,7 @@ module.exports = function() {
             'attributes': {
               'hostname': '127.0.0.1',
               'port': 3389,
-              'username': null,
+              'username': 'Administrator',
               'password': null,
               'remote-app': '',
               'protocol': 'rdp',

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -26,6 +26,7 @@
 
 const assert = require('chai').assert;
 const request = require('request-promise');
+const Promise = require('bluebird');
 
 describe('Machine Service', () => {
   describe('Broker', () => {
@@ -53,27 +54,34 @@ describe('Machine Service', () => {
             id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
             name: 'Admin'
           })
-          .then(() => {
-            return Machine.count();
-          })
-          .then((machineNbr) => {
-            if (machineNbr !== conf.machinePoolSize + 1) {
-              throw new Error('A new machine should be created');
-            }
-          })
-          .then(() => {
-            return Machine.count({
-              user: null
+            .then(() => {
+              return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  Machine.count()
+                    .then((machineNbr) => {
+
+                      if (machineNbr !== conf.machinePoolSize + 1) {
+                        return reject('A new machine should be created');
+                      }
+
+                      return resolve();
+                    });
+                }, 10);
+              });
+            })
+            .then(() => {
+              return Machine.count({
+                user: null
+              });
+            })
+            .then((machineNbr) => {
+              if (machineNbr !== conf.machinePoolSize) {
+                throw new Error('One machine should belongs to the admin');
+              }
+            })
+            .then(() => {
+              return done();
             });
-          })
-          .then((machineNbr) => {
-            if (machineNbr !== conf.machinePoolSize) {
-              throw new Error('One machine should belongs to the admin');
-            }
-          })
-          .then(() => {
-            return done();
-          });
         });
       });
     });


### PR DESCRIPTION
Fixed #50 and #48 

Fix MachineService.sessionEnded never called
Attributes set by guacamole were not properly checked (checked in kebab-case where values were already deserialized)

Fix plaza was called with the wrong arguments when trying to list sessions
Set Administrator as username for every machine created by dummy driver
Previsouly username was set to null which created issue as fake plaza expected a username to determine opened sessions

Fixed #48 connection to VDI did not work the first try
GetMachineForUser used to wait for the brocker to create all machines. This is long operation that delayed the VDI start if the user had to be affected a machine.
Updates test to take into account pool size updates now take place in background
