### PR TITLE
Fix regular users were able to retrieve list of all machines

### DIFF
--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -33,11 +33,19 @@ module.exports = {
    * @method find
    */
   find(req, res) {
-    MachineService.machines()
-      .then((machines) => {
-        return res.ok(machines);
-      })
-      .catch((err) => res.negotiate(err));
+    if (req.user.isAdmin) {
+      Machine.find()
+        .then((machines) => {
+          return res.ok(machines);
+        })
+        .catch((err) => res.negotiate(err));
+    } else {
+      MachineService.getMachineForUser(req.user)
+        .then((machines) => {
+          return res.ok([machines]);
+        })
+        .catch((err) => res.negotiate(err));
+    }
   },
 
   /**
@@ -51,9 +59,9 @@ module.exports = {
    * @method users
    */
   users(req, res) {
-    Machine.find()
+    MachineService.getMachineForUser(req.user)
       .then((machines) => {
-        return res.ok(machines);
+        return res.ok([machines]);
       })
       .catch((err) => res.negotiate(err));
   }

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -34,6 +34,7 @@ const testConfig = require('./config.test');
 const testGroup = require('./group.test');
 const testApps = require('./apps.test');
 const testSecurity = require('./security.test');
+const testMachine = require('./machine.test');
 
 var request = require('supertest');
 
@@ -57,3 +58,4 @@ testConfig();
 testGroup();
 testApps();
 testSecurity();
+testMachine();

--- a/tests/api/machine.test.js
+++ b/tests/api/machine.test.js
@@ -1,0 +1,119 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* globals sails, AccessToken, User, Machine */
+
+var nano = require('./lib/nanotest');
+
+module.exports = function() {
+
+  describe('machine', function() {
+
+    let user = null;
+    let token = null;
+
+    before('Add proper user and machines for testing', function(done) {
+      User.create({
+        firstName: 'Test',
+        lastName: 'Test',
+        password: 'tests',
+        email: 'test@test.com',
+        isAdmin: false,
+        expirationDate: null,
+      })
+        .then((res) => {
+          user = res;
+          return Machine.create({
+            user: user.id,
+            name: 'essai1',
+            type: 'manual',
+            ip: '1.1.1.1',
+            username: 'Administrator',
+            password: 'admin'
+          },
+          {
+            name: 'essai2',
+            type: 'manual',
+            ip: '2.2.2.2',
+            username: 'Administrator',
+            password: 'admin'
+          });
+        })
+        .then(() => {
+          return AccessToken.create({
+            userId: user.id
+          });
+        })
+        .then((res) => {
+          token = res;
+          return done();
+        });
+    });
+
+    after('Remove created user and machines', function(done) {
+      User.destroy({firstName: 'Test'})
+        .then(() => {
+          return Machine.destroy({
+            name: ['essai1', 'essai2']
+          });
+        })
+        .then(() => done());
+    });
+
+    it('Should return user machines', function(done) {
+      nano.request(sails.hooks.http.app)
+        .get('/api/machines')
+        .set('Authorization', 'Bearer ' + token.token)
+        .expect(200)
+        .expect((res) => {
+          if (res.body.data.length !== 1) {
+            throw new Error('Regular users should not be able to list all machines');
+          }
+        })
+        .then(() => {
+          nano.request(sails.hooks.http.app)
+            .get('/api/machines')
+            .set(nano.adminLogin())
+            .expect(200)
+            .expect((res) => {
+              if (res.body.data.length <= 1) {
+                throw new Error('Admins should be able to list all machines');
+              }
+            });
+        })
+        .then(() => {
+          nano.request(sails.hooks.http.app)
+            .get('/api/machines/users')
+            .set('Authorization', 'Bearer ' + token.token)
+            .expect(200)
+            .expect((res) => {
+              if (res.body.data.length !== 1) {
+                throw new Error('All users should be able to list only their machines');
+              }
+            })
+            .end(done);
+        });
+    });
+  });
+};


### PR DESCRIPTION
In response to issue #49
Replace machine() with getMachineForUser() for list only machines of the user
getMachineForUser don't return an array, add [].
Admins should still be able to list all machines.
`api/machines/users` list only user's machines.
