### PR TITLE
Regular users cannot see group they are in from their profile page

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -29,6 +29,13 @@
 
 module.exports = {
 
+  findOne: function(req, res) {
+    return User.findOne(req.allParams().id)
+    .populate('groups')
+    .then((res.ok))
+    .catch(res.negotiate);
+  },
+
   find: function(req, res) {
 
     if (req.allParams().me === 'true') {
@@ -39,7 +46,7 @@ module.exports = {
 
     return User.find()
       .populate('groups')
-      .then((res.ok))
+      .then(res.ok)
       .catch(res.negotiate);
   }
 };

--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -1,66 +1,68 @@
 <div class="user-detail m-t-2">
-	<h4 class="name-row">
-		{{#if model.isAdmin }}
-			{{#link-to 'protected.users'}}Users{{/link-to}} -
-		{{/if}}
-		{{#edit-text
-			class='in-bl'
-			type="text"
-			confirmation=false
-			textInput=model.firstName
-			textInputPlaceholder="First name"
-			onClose="changeFirstName"
-		}}
-			{{model.firstName}}
-		{{/edit-text}}
-		{{#edit-text
-			class='in-bl px-l-5'
-			type="text"
-			confirmation=false
-			textInput=model.lastName
-			textInputPlaceholder="Last name"
-			onClose="changeLastName"
-		}}
-			{{model.lastName}}
-		{{/edit-text}}
+  <h4 class="name-row">
+    {{#if model.isAdmin }}
+      {{#link-to 'protected.users'}}Users{{/link-to}} -
+    {{/if}}
+    {{#edit-text
+      class='in-bl'
+      type="text"
+      confirmation=false
+      textInput=model.firstName
+      textInputPlaceholder="First name"
+      onClose="changeFirstName"
+    }}
+      {{model.firstName}}
+    {{/edit-text}}
+    {{#edit-text
+      class='in-bl px-l-5'
+      type="text"
+      confirmation=false
+      textInput=model.lastName
+      textInputPlaceholder="Last name"
+      onClose="changeLastName"
+    }}
+      {{model.lastName}}
+    {{/edit-text}}
 
-		{{#if model.isAdmin}}
-			<i class="material-icons va-bottom">verified_user</i>
-		{{/if}}
-	</h4>
-	<div class='content-wrapper'>
-		<table class="table user-table">
-			<tbody>
-				<tr>
-					<th scope="row">Email address</th>
-					<td>
-						{{#edit-text
-							type="email"
-							confirmation=false
-							textInput=model.email
-							textInputPlaceholder="Email"
-							onClose="changeEmail" }}
-							{{model.email}}
-						{{/edit-text}}
-					</td>
-				</tr>
-				<tr>
-					<th scope="row">Password</th>
-            <td>
-						{{#edit-text
-							type="password"
-							confirmation=true
-							textInput=model.password
-							textInputPlaceholder="Password"
-							confirmInput=passwordConfirmation
-							confirmInputPlaceholder="Confirmation"
-							onClose="changePassword" }}
+    {{#if model.isAdmin}}
+      <i class="material-icons va-bottom">verified_user</i>
+    {{/if}}
+  </h4>
+  <div class='content-wrapper'>
+    <table class="table user-table">
+      <tbody>
+        <tr>
+          <th scope="row">Email address</th>
+          <td>
+            {{#edit-text
+              type="email"
+              confirmation=false
+              textInput=model.email
+              textInputPlaceholder="Email"
+              onClose="changeEmail"
+            }}
+              {{model.email}}
+            {{/edit-text}}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Password</th>
+          <td>
+            {{#edit-text
+              type="password"
+              confirmation=true
+              textInput=model.password
+              textInputPlaceholder="Password"
+              confirmInput=passwordConfirmation
+              confirmInputPlaceholder="Confirmation"
+              onClose="changePassword"
+            }}
               <span class="va-bottom">
-							******
+                ******
               </span>
-						{{/edit-text}}
-					</td>
-				</tr>
+            {{/edit-text}}
+          </td>
+        </tr>
         <tr>
           <th scope="row">
             {{#if session.user.isAdmin}}
@@ -68,77 +70,78 @@
                 Group(s)
               {{/link-to}}
             {{else}}
-                Group(s)
+              Group(s)
             {{/if}}
           </th>
           <td>
             {{#each model.groups as |group index|}}
-              {{#if index}},{{/if}}
+            {{#if index}},{{/if}}
               {{#if session.user.isAdmin}}
                 <span class="in-bl">
                   {{#link-to 'protected.users.groups.group' group.id}} {{group.name}} {{/link-to}}
                 </span>
               {{else}}
-                  {{group.name}}
+                {{group.name}}
               {{/if}}
             {{else}}
               No group
             {{/each}}
           </td>
         </tr>
-		<tr>
+        <tr>
           <th scope="row">Expiration date</th>
           <td>
-              {{#if session.user.isAdmin }}
-                  {{#edit-text
-                    type="number"
-                    confirmation=false
-                    textInput=expirationDays
-                    textInputPlaceholder="Days left before expiration"
-                    onClose="changeExpirationDays" }}
-                        {{#if model.expirationDate}}
-                          {{moment-calendar model.expirationDateInMs}}
-                        {{else}}
-                          No expiration date set
-                        {{/if}}
-                    {{/edit-text}}
-              {{else}}
-                  {{moment-calendar model.expirationDate}}
-              {{/if}}
+            {{#if session.user.isAdmin }}
+              {{#edit-text
+                type="number"
+                confirmation=false
+                textInput=expirationDays
+                textInputPlaceholder="Days left before expiration"
+                onClose="changeExpirationDays"
+              }}
+                {{#if model.expirationDate}}
+                  {{moment-calendar model.expirationDateInMs}}
+                {{else}}
+                  No expiration date set
+                {{/if}}
+              {{/edit-text}}
+            {{else}}
+              {{moment-calendar model.expirationDate}}
+            {{/if}}
           </td>
-		</tr>
+        </tr>
         <tr>
           <th scope="row">Creation date</th>
           <td>
             {{moment-calendar model.createdAt}}
           </td>
         </tr>
-				{{#if session.user.isAdmin }}
-					<tr>
-						<th scope="row">UUID</th>
+        {{#if session.user.isAdmin }}
+          <tr>
+            <th scope="row">UUID</th>
             <td>
               {{model.id}}
               {{copy-clipboard class='in-bl' value=model.id title='UUID'}}
             </td>
-					</tr>
-					<tr>
-						<th scope="row">Delete Account</th>
-						<td>
-							{{ remove-user action="removeDone" }}
-						</td>
-					</tr>
+          </tr>
+          <tr>
+            <th scope="row">Delete Account</th>
+            <td>
+              {{ remove-user action="removeDone" }}
+            </td>
+          </tr>
           <tr>
             <th scope="row">Is admin</th>
             <td>
               {{#if isMe }}
                 {{input type="checkbox" name="isAdmin" change=(action "updatePrivilege") checked=model.isAdmin disabled="isMe"}}
               {{else}}
-                {{input type="checkbox" name="isAdmin" change=(action "updatePrivilege") checked=model.isAdmin}}
+              {{input type="checkbox" name="isAdmin" change=(action "updatePrivilege") checked=model.isAdmin}}
               {{/if}}
             </td>
           </tr>
-				{{/if}}
-			</tbody>
-		</table>
-	</div>
+        {{/if}}
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/config/passport.js
+++ b/config/passport.js
@@ -116,11 +116,12 @@ passport.use(new BearerStrategy(
       User.findOne({
         id: token.userId
       })
-        .exec(function (err, user) {
-          User.findOne({
-            id: token.userId
-          },done(err,user,info));
-        });
+      .populate('groups')
+      .exec(function (err, user) {
+        User.findOne({
+          id: token.userId
+        },done(err,user,info));
+      });
     });
   }
 ));


### PR DESCRIPTION
This problem occurs when we attempt to retrieve a single user. The backend does not populate the 'groups' property. To fix that, I ensure the relationships are correctly sent.
Additionally, there was an indent issue in the template file that has been fixed.

Fixes #87 
