### PR TITLE
Bugfix: History gives "invalid date" as end date for still opened sessions

### DIFF
--- a/assets/app/history/model.js
+++ b/assets/app/history/model.js
@@ -1,6 +1,5 @@
 /**
- * Nanocloud turns any traditional software into a cloud solution, without
- * changing or redeveloping existing source code.
+ * Nanocloud turns any traditional software into a cloud solution, without * changing or redeveloping existing source code.
  *
  * Copyright (C) 2016 Nanocloud Software
  *
@@ -44,5 +43,8 @@ export default DS.Model.extend({
   }),
   userFullName: Ember.computed('userFirstname', 'userLastname', function() {
     return this.get('userFirstname') + ' ' + this.get('userLastname');
+  }),
+  isActive: Ember.computed('endDate', function() {
+    return this.get('endDate').toString() === 'Invalid Date';
   })
 });

--- a/assets/app/protected/histories/index/controller.js
+++ b/assets/app/protected/histories/index/controller.js
@@ -75,6 +75,7 @@ export default Ember.Controller.extend({
         machineSize: item.get('machineSize'),
         start: window.moment(item.get('startDate')).format('MMMM Do YYYY, h:mm:ss A'),
         end: window.moment(item.get('endDate')).format('MMMM Do YYYY, h:mm:ss A'),
+        isActive: item.get('isActive'),
         duration: item.get('duration') / 1000,
       }));
     });
@@ -123,13 +124,12 @@ export default Ember.Controller.extend({
       filterWithSelect: false,
     },
     {
-      propertyName: 'end',
       title: 'End Date',
       disableFiltering: true,
       filterWithSelect: false,
+      template: 'protected/histories/index/table/history-list/end-date',
     },
     {
-      propertyName: 'duration',
       title: 'Total duration',
       disableFiltering: true,
       filterWithSelect: false,

--- a/assets/app/protected/histories/index/table/history-list/duration/template.hbs
+++ b/assets/app/protected/histories/index/table/history-list/duration/template.hbs
@@ -1,1 +1,5 @@
-{{format-duration record.duration}}
+{{#if record.isActive}}
+  <span class='color-success'>Active</span>
+{{else}}
+  {{format-duration record.duration}}
+{{/if}}

--- a/assets/app/protected/histories/index/table/history-list/end-date/template.hbs
+++ b/assets/app/protected/histories/index/table/history-list/end-date/template.hbs
@@ -1,0 +1,5 @@
+{{#if record.isActive}}
+  -
+{{else}}
+  {{record.end}}
+{{/if}}


### PR DESCRIPTION
In history page, the 'endDate' value is 'Invalid Date' when it's undefined.
This message should not be displayed so to fix that, I kept that column blank and set the 'duration' value to 'active'

Fixes #86 
