### PR TITLE
Bug: Machine detail page is blank

### DIFF
--- a/assets/app/protected/machines/machine/controller.js
+++ b/assets/app/protected/machines/machine/controller.js
@@ -26,7 +26,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   loadState: false,
-  user: Ember.computed('model.users', () => {
+  user: Ember.computed('model.users', function() {
     var user = this.get('model.users');
     return user ? user.objectAt(0) : null;
   }),


### PR DESCRIPTION
An error was introduced in previous changes. We should not be using arrow function with computed property because 'this' is set to its top-level context which doesn't have a this.
To fix that, we use the old-style anonymous function.
