### PR TITLE
Fixes: Typo in groups, Text not correctly positioned in configs, Error when setting defaultGroup

### DIFF
--- a/assets/app/protected/configs/controller.js
+++ b/assets/app/protected/configs/controller.js
@@ -48,7 +48,6 @@ export default Ember.Controller.extend({
     if (this.get('loadState') === true) {
       if (this.get('autoRegister') === false) {
         this.set('defaultGroup', '');
-        this.saveKey(null, 'defaultGroup');
       }
     }
   }.observes('autoRegister'),
@@ -76,7 +75,6 @@ export default Ember.Controller.extend({
       else {
         this.set('defaultGroup', id);
       }
-      this.saveKey(null, 'defaultGroup');
     },
   }
 });

--- a/assets/app/protected/configs/user-right/template.hbs
+++ b/assets/app/protected/configs/user-right/template.hbs
@@ -33,13 +33,13 @@
     </ul>
   {{/if}}
   <div class="form-group row">
-    <div class="col-sm-2">
-      <p class="confirm-input-item color-primary">You can enter an expiration date for new users (in days):</p>
+    <div class="col-sm-4">
+      <p class="confirm-input-item color-primary in-bl fl">You can enter an expiration date for new users (in days):</p>
     </div>
     <div class="col-sm-2">{{input-confirm value=configController.expirationDate type="number" min="1"}}</div>
   </div>
 {{/if}}
-<div>
+<div class='m-t-2'>
   {{input type="checkbox" checked=configController.autoLogoff}}
   <label for="cbox2">Logoff after closing VDI</label>
 </div>

--- a/assets/app/protected/users/groups/index/controller.js
+++ b/assets/app/protected/users/groups/index/controller.js
@@ -76,13 +76,13 @@ export default Ember.Controller.extend({
     },
     {
       propertyName: 'members',
-      title: 'number of member',
+      title: 'Number of members',
       disableFiltering: true,
       filterWithSelect: false
     },
     {
       propertyName: 'apps',
-      title: 'number of application',
+      title: 'Number of applications',
       disableFiltering: true,
       filterWithSelect: false
     },


### PR DESCRIPTION
- fix typos in group page.
  "number of member => Number of members”
  "number of application" => “Number of applications"
- in config/user-right, The description text for expiration date is not positioned properly
- in config/user-right, Setting defaultGroup option triggers 2 POST request to the API instead of 1.
