### PR TITLE
Fix probability guacamole could not retrieve connection list nor log history if provided access token had become invalid

### DIFF
--- a/api/controllers/HistoryController.js
+++ b/api/controllers/HistoryController.js
@@ -25,7 +25,7 @@
  * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
 
-/* global Machine, MachineService, JsonApiService, History */
+/* global Machine, MachineService, JsonApiService */
 
 const _= require('lodash');
 

--- a/api/policies/isGuacamole.js
+++ b/api/policies/isGuacamole.js
@@ -1,0 +1,36 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Pass to next middleware only if incoming request comes from Guacamole
+ * For now we consider a request to originate from Guacamole if req.host is set to
+ * "localhost:1337" which is the case for guacamole because it directly targets
+ * the backend without passing through the proxy
+ */
+module.exports = function(req, res, next) {
+
+  if (req.get('host') === 'localhost:1337') {
+    return next(null);
+  }
+
+  return res.send(401, 'Request did not originate from local network');
+};

--- a/assets/app/remote-session/service.js
+++ b/assets/app/remote-session/service.js
@@ -91,6 +91,7 @@ export default Ember.Service.extend(Ember.Evented, {
   getSession: function(name, width, height) {
 
     this.set('isError', false);
+    this.notifyPropertyChange('guacToken');
     return this.get('guacToken').then((token) => {
 
       let tunnel = new Guacamole.WebSocketTunnel('/guacamole/websocket-tunnel?' + this._forgeConnectionString(token.authToken, name, width, height));

--- a/config/policies.js
+++ b/config/policies.js
@@ -69,6 +69,8 @@ module.exports.policies = {
   },
 
   HistoryController : {
-    destroy: false
+    destroy: false,
+    create: ['isGuacamole'],
+    update: ['isGuacamole']
   },
 };

--- a/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
+++ b/guacamole-client/noauth-logged/src/main/java/com/nanocloud/auth/noauthlogged/connection/LoggedConnection.java
@@ -81,7 +81,6 @@ public class LoggedConnection extends SimpleConnection {
       String machineId = data.getString("id");
       dataAttribute = data.getJSONObject("attributes");
       String machineDriver = dataAttribute.getString("type");
-      String flavor = dataAttribute.getString("flavor");
 
       URL myUrl = new URL("http://" + hostname + ":" + port + "/" + endpoint);
       HttpURLConnection urlConn = (HttpURLConnection)myUrl.openConnection();
@@ -102,7 +101,7 @@ public class LoggedConnection extends SimpleConnection {
               .add("end-date", "")
               .add("machine-id", machineId)
               .add("machine-driver", machineDriver)
-              .add("machine-type", flavor)))
+              .add("machine-type", "")))
         .build();
 
       urlConn.setUseCaches(false);

--- a/tests/api/histories.test.js
+++ b/tests/api/histories.test.js
@@ -22,7 +22,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* global Histories, sails */
+/* global MachineService, sails */
 
 var nano = require('./lib/nanotest');
 var expect = require('chai').expect;
@@ -30,10 +30,6 @@ var expect = require('chai').expect;
 module.exports = function() {
 
   describe('Histories', function() {
-
-    afterEach('Cleaning database', () => {
-      Histories.query('TRUNCATE TABLE public.history');
-    });
 
     const expectedSchema = {
       type: 'object',
@@ -46,90 +42,78 @@ module.exports = function() {
         'start-date': {type: 'string'},
         'end-date': {type: 'string'},
         'machine-id': {type: 'string'},
-        'machine-size': {type: 'string'},
         'machine-driver': {type: 'string'},
         'created-at': {type: 'string'},
         'updated-at': {type: 'string'}
       },
-      required: ['user-mail','user-id','user-firstname','user-lastname','connection-id','start-date','end-date','machine-id','machine-size','machine-driver','created-at','updated-at'],
+      required: ['user-mail','user-id','user-firstname','user-lastname','connection-id','start-date','end-date','machine-id','machine-driver','created-at','updated-at'],
       additionalProperties: false
     };
 
-    describe('Create history', () => {
-      it('Should create history', (done) => {
-        nano.request(sails.hooks.http.app)
-        .post('/api/histories')
-        .send({
-          data: {
-            attributes: {
-              'user-mail': 'admin@nanocloud.com',
-              'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
-              'user-firstname': 'Admin',
-              'user-lastname': 'Nanocloud',
-              'connection-id': 'Desktop',
-              'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
-              'end-date': '',
-              'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
-              'machine-size': '',
-              'machine-driver': 'dummy'
-            },
-            type: 'histories'
-          }
-        })
-        .set('Authorization', 'Bearer admintoken')
-        .expect(201)
-        .expect(nano.jsonApiSchema(expectedSchema))
-        .then(() => {
-          return nano.request(sails.hooks.http.app)
-          .get('/api/hitories')
-          .expect(200)
-          .expect(nano.jsonApiSchema(expectedSchema))
-          .expect((res) => {
-            expect(res.body.data[0].attributes.startDate).to.equal('Wed Jul 21 14:10:00 UTC 2016');
-          });
-        })
-        .then((res) => {
-          return nano.request(sails.hooks.http.app)
-          .post('/api/histories/' + res.body.data[0].id)
-          .send({
-            data: {
-              attributes: {
-                'user-mail': 'admin@nanocloud.com',
-                'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
-                'user-firstname': 'Admin',
-                'user-lastname': 'Nanocloud',
-                'connection-id': 'Desktop',
-                'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
-                'end-date': 'Wed Jul 21 14:20:00 UTC 2016',
-                'machine-id': 'f7362994-a8df-4ed6-89f5-99092b145999',
-                'machine-size': '',
-                'machine-driver': 'dummy'
-              },
-              type: 'histories'
-            }
-          })
-          .set('Authorization', 'Bearer admintoken')
-          .expect(200)
-          .expect(nano.jsonApiSchema(expectedSchema))
-          .expect((res) => {
-            expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
-          });
-        })
-        .end(done);
-      });
-
-      it('Should return created history', (done) => {
-        nano.request(sails.hooks.http.app)
-        .get('/api/histories')
-        .set('Authorization', 'Bearer admintoken')
-        .expect(200)
-        .expect(nano.jsonApiSchema(expectedSchema))
-        .expect((res) => {
-          expect(res.body.data[0].attributes.endDate).to.equal('Wed Jul 21 14:20:00 UTC 2016');
-        })
-        .end(done);
-      });
-
+    it('Should create history', (done) => {
+      MachineService.getMachineForUser({
+        id: nano.adminId()
+      })
+        .then((machine) => {
+          nano.request('http://localhost:1337')
+            .post('/api/histories')
+            .send({
+              data: {
+                attributes: {
+                  'user-mail': 'admin@nanocloud.com',
+                  'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                  'user-firstname': 'Admin',
+                  'user-lastname': 'Nanocloud',
+                  'connection-id': 'Desktop',
+                  'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+                  'end-date': '',
+                  'machine-id': machine.id,
+                  'machine-driver': 'dummy'
+                },
+                type: 'histories'
+              }
+            })
+            .expect(201)
+            .expect(nano.jsonApiSchema(expectedSchema))
+            .then(() => {
+              return nano.request(sails.hooks.http.app)
+                .get('/api/histories')
+                .set(nano.adminLogin())
+                .expect(200)
+                .expect(nano.jsonApiSchema(expectedSchema))
+                .expect((res) => {
+                  expect(res.body.data[0].attributes['start-date']).to.equal('Wed Jul 21 14:10:00 UTC 2016');
+                })
+                .then((res) => {
+                  return nano.request('http://localhost:1337')
+                    .post('/api/histories/' + res.body.data[0].id)
+                    .send({
+                      data: {
+                        attributes: {
+                          'user-mail': 'admin@nanocloud.com',
+                          'user-id': 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+                          'user-firstname': 'Admin',
+                          'user-lastname': 'Nanocloud',
+                          'connection-id': 'Desktop',
+                          'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
+                          'end-date': 'Wed Jul 21 14:20:00 UTC 2016',
+                          'machine-id': machine.id,
+                          'machine-driver': 'dummy'
+                        },
+                        type: 'histories'
+                      }
+                    })
+                    .expect(200)
+                    .expect(nano.jsonApiSchema(expectedSchema))
+                    .expect((res) => {
+                      expect(res.body.data.attributes['end-date']).to.equal('Wed Jul 21 14:20:00 UTC 2016');
+                    })
+                    .then(() => {
+                      return done();
+                    });
+                });
+            });
+        });
     });
   });
 };

--- a/tests/api/histories.test.js
+++ b/tests/api/histories.test.js
@@ -43,6 +43,8 @@ module.exports = function() {
         'end-date': {type: 'string'},
         'machine-id': {type: 'string'},
         'machine-driver': {type: 'string'},
+        'machine-size': {type: 'string'},
+        'machine-type': {type: 'string'},
         'created-at': {type: 'string'},
         'updated-at': {type: 'string'}
       },
@@ -68,7 +70,8 @@ module.exports = function() {
                   'start-date': 'Wed Jul 21 14:10:00 UTC 2016',
                   'end-date': '',
                   'machine-id': machine.id,
-                  'machine-driver': 'dummy'
+                  'machine-driver': 'dummy',
+                  'machine-type': ''
                 },
                 type: 'histories'
               }

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -36,6 +36,7 @@ const testApps = require('./apps.test');
 const testSecurity = require('./security.test');
 const testMachine = require('./machine.test');
 const testImage = require('./image.test');
+const testHistories = require('./histories.test');
 
 var request = require('supertest');
 
@@ -59,5 +60,6 @@ testConfig();
 testGroup();
 testApps();
 testSecurity();
+testHistories();
 testMachine();
 testImage();

--- a/tests/api/security.test.js
+++ b/tests/api/security.test.js
@@ -22,22 +22,113 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* globals sails*/
+/* globals sails, MachineService */
 
 const nano = require('./lib/nanotest');
 
 module.exports = function() {
 
   describe('Security', function() {
+    describe('History', function() {
+      describe('Create history - Only possible from Guacamole', function() {
 
-    describe('Delete history', function() {
+        it('Should not create history with no token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .post('/api/histories')
+            .send({})
+            .expect(401)
+            .end(done);
+        });
+        it('Should not create history even with token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .post('/api/histories')
+            .send({})
+            .set(nano.adminLogin())
+            .expect(401)
+            .end(done);
+        });
+        it('Should not create history if coming from Guacamole', function(done) {
+          MachineService.getMachineForUser({
+            id: nano.adminId()
+          })
+            .then(() => {
+              nano.request('http://localhost:1337')
+                .post('/api/histories')
+                .send()
+                .expect(400)
+                .end(done);
+            });
+        });
+      });
 
-      it('Should not delete history', function(done) {
-        nano.request(sails.hooks.http.app)
-          .delete('/api/histories')
-          .set(nano.adminLogin())
-          .expect(403)
-          .end(done);
+      describe('Read history - Only possible has loggedin user', function() {
+        it('Should not return history with no token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .get('/api/histories')
+            .expect(401)
+            .end(done);
+        });
+        it('Should return history with token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .get('/api/histories')
+            .set(nano.adminLogin())
+            .expect(200)
+            .end(done);
+        });
+    });
+
+      describe('Update history - Only possible from Guacamole', function() {
+
+        it('Should not update history with no token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .post('/api/histories/')
+            .send({})
+            .expect(401)
+            .end(done);
+        });
+        it('Should not create history even with token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .post('/api/histories')
+            .send({})
+            .set(nano.adminLogin())
+            .expect(401)
+            .end(done);
+        });
+        it('Should not create history if coming from Guacamole', function(done) {
+          MachineService.getMachineForUser({
+            id: nano.adminId()
+          })
+            .then(() => {
+              nano.request('http://localhost:1337')
+                .post('/api/histories/' + 'fakeid')
+                .send([])
+                .expect(400)
+                .end(done);
+            });
+        });
+      });
+
+      describe('Delete history', function() {
+
+        it('Should not delete with no token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .delete('/api/histories')
+            .expect(403)
+            .end(done);
+        });
+        it('Should not delete even with a token', function(done) {
+          nano.request(sails.hooks.http.app)
+            .delete('/api/histories')
+            .set(nano.adminLogin())
+            .expect(403)
+            .end(done);
+        });
+        it('Should not delete even from guacamole', function(done) {
+          nano.request('http://localhost:1337')
+            .delete('/api/histories')
+            .expect(403)
+            .end(done);
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #107 
Fixes #41 

Force frontend to ask guacamole a new authentication token at each connection. This force Guacamole to actualize connection list with a valid token at each connetion to the VDI.

Remove the need for an access token to log history as long as connection is made from Guacamole.
