### PR TITLE
Add windows sessions list and deletion

### DIFF
--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -1,0 +1,54 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+const Promise = require('bluebird');
+const _ = require('lodash');
+
+/* globals Machine */
+
+module.exports = {
+
+  find: function(req, res) {
+
+    Machine.find()
+      .then((machines) => {
+
+        let sessionsRequest = [];
+        machines.forEach((machine) => {
+          sessionsRequest.push(machine.getSessions());
+        });
+
+        Promise.all(sessionsRequest)
+          .timeout(2000)
+          .then((sessions) => {
+
+            sessions = _.reject(sessions, _.isEmpty);
+            sessions = _.flatten(sessions);
+
+            return res.ok(sessions);
+          })
+          .catch(res.negotiate);
+      });
+  }
+};

--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -25,7 +25,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 
-/* globals Machine */
+/* globals Machine, MachineService */
 
 module.exports = {
 
@@ -50,5 +50,19 @@ module.exports = {
           })
           .catch(res.negotiate);
       });
+  },
+
+  disconnect: function(req, res) {
+
+    MachineService.getMachineForUser(req.user)
+      .then((machine) => {
+        return machine.killSession();
+      })
+      .then(() => {
+        return res.json({
+          meta: {}
+        });
+      })
+      .catch((err) => res.negotiate(err));
   }
 };

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -47,7 +47,7 @@ class DummyDriver extends BaseDriver {
     var FakePlaza = http.createServer((req, res) => {
       res.writeHead(200, {'Content-Type': 'application/json'});
 
-      if (req.url === '/sessions/Administrator') {
+      if (req.url === '/sessions/Administrator' && req.method === 'GET') {
 
         let status = (_sessionOpen === true) ? 'Active' : 'Inactive';
         let data = {
@@ -62,6 +62,8 @@ class DummyDriver extends BaseDriver {
         };
 
         return res.end(JSON.stringify(data));
+      } else if (req.url === '/sessions/Administrator' && req.method === 'DELETE') {
+        _sessionOpen = false;
       } else if (req.url === '/sessionOpen') {
         _sessionOpen = true;
       } else if (req.url === '/sessionClose') {

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -80,7 +80,14 @@ module.exports = {
       });
     },
 
-    isSessionActive() {
+    /*
+     * Get informations about sessions on this machines
+     *
+     * @method getSessions
+     * @return {Promise[Array]} a promise resolving to an array of session
+     */
+    getSessions() {
+
       let plazaAddr = url.format({
         protocol: 'http',
         hostname: this.ip,
@@ -88,26 +95,43 @@ module.exports = {
         pathname: '/sessions/' + this.username
       });
 
-      return request.getAsync(plazaAddr).then((res) => {
-        let body = res.body;
+      return request.getAsync(plazaAddr)
+        .then((res) => {
+          let body = res.body;
 
-        try {
-          body = JSON.parse(body);
-        } catch (err) {
-          return Promise.reject(err);
-        }
-
-        const data = body.data;
-
-        if (data.length) {
-          const status = data[0][3];
-
-          if (status === 'Active') {
-            return true;
+          try {
+            body = JSON.parse(body);
+          } catch (err) {
+            return Promise.reject(err);
           }
-        }
-        return false;
-      });
+
+          let sessions = [];
+          body.data.forEach((session) => {
+            sessions.push({
+              id: uuid.v4(), // id does not matter for session but is required for JSON API
+              username: session[1],
+              state: session[3],
+              userId: this.user
+            });
+          });
+
+          return sessions;
+        });
+    },
+
+    isSessionActive() {
+
+      return this.getSessions()
+        .then((sessions) => {
+          if (sessions.length) {
+            const status = sessions[0].state;
+
+            if (status === 'Active') {
+              return true;
+            }
+          }
+          return false;
+        });
     }
   }
 };

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -119,6 +119,12 @@ module.exports = {
         });
     },
 
+    /*
+     * Get status information about first session on this machine
+     *
+     * @method isSessionActive
+     * @return {Boolean} True if a session is active on this machine, False otherwise
+     */
     isSessionActive() {
 
       return this.getSessions()
@@ -131,6 +137,31 @@ module.exports = {
             }
           }
           return false;
+        });
+    },
+
+    /*
+     * Kill active session on machine
+     *
+     * @method killSession
+     * @return {String} Message to tell user whether the session has been revoked or not
+     */
+    killSession() {
+      let plazaAddr = url.format({
+        protocol: 'http',
+        hostname: this.ip,
+        port: this.plazaport,
+        pathname: '/sessions/' + this.username
+      });
+
+      return request.deleteAsync(plazaAddr)
+        .then((res) => {
+
+          if (res.statusCode !== 200) {
+            return Promise.reject('Plaza agent did not end user\'s session');
+          }
+
+          return Promise.resolve();
         });
     }
   }

--- a/api/models/Session.js
+++ b/api/models/Session.js
@@ -1,0 +1,30 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+module.exports = {
+
+  attributes: {
+
+  }
+};

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -171,7 +171,9 @@ function getMachineForUser(user) {
 
                 if (res.rows.length) {
                   _updateMachinesPool();
-                  return resolve(res.rows[0]);
+                  return resolve(Machine.findOne({
+                    id: res.rows[0].id
+                  }));
                 }
 
                 return reject(noMachineFoundError);

--- a/assets/app/protected/dashboard/controller.js
+++ b/assets/app/protected/dashboard/controller.js
@@ -46,8 +46,7 @@ export default Ember.Controller.extend({
   }),
 
   sessions: Ember.computed('model.sessions', 'model.sessions', function() {
-    return this.get('model.sessions')
-      .rejectBy('username', 'Administrator');
+    return this.get('model.sessions');
   }),
 
   machines: Ember.computed('model.machines', 'model.machines', function() {

--- a/config/routes.js
+++ b/config/routes.js
@@ -108,6 +108,11 @@ module.exports.routes = {
   'GET /api/files/download': {
     controller: 'Storage',
     action: 'download'
+  },
+
+  'DELETE /api/sessions': {
+    controller: 'Session',
+    action: 'disconnect'
   }
 
 };

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -34,6 +34,7 @@ const testConfig = require('./config.test');
 const testGroup = require('./group.test');
 const testApps = require('./apps.test');
 const testSecurity = require('./security.test');
+const testSession = require('./session.test');
 const testMachine = require('./machine.test');
 const testImage = require('./image.test');
 
@@ -61,3 +62,4 @@ testApps();
 testSecurity();
 testMachine();
 testImage();
+testSession();

--- a/tests/api/session.test.js
+++ b/tests/api/session.test.js
@@ -1,0 +1,74 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* globals sails */
+
+const nano = require('./lib/nanotest');
+const expect = require('chai').expect;
+
+module.exports = function() {
+
+  describe('Session', function() {
+
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        'username': {type: 'string'},
+        'state': {type: 'string'},
+        'user-id': {type: ['string', 'null']}
+      },
+      required: ['username', 'state'],
+      additionalProperties: false
+    };
+
+    describe('List sessions', function() {
+      it('Should return a list of inactive sessions', function(done) {
+
+        nano.request(sails.hooks.http.app)
+        .get('/api/sessions')
+        .set(nano.adminLogin())
+        .expect(200)
+        .expect(nano.jsonApiSchema(expectedSchema))
+        .expect((res) => {
+          expect(res.body.data.length).to.be.at.least(1);
+          expect(res.body.data[0].attributes.state).to.equal('Inactive');
+        })
+        .end(done);
+      });
+    });
+
+    describe('Delete current user\'s session', function() {
+      it('Should end user\'s session', function(done) {
+        nano.request(sails.hooks.http.app)
+        .delete('/api/sessions')
+        .set(nano.adminLogin())
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).to.have.property('meta');
+        })
+        .end(done);
+      });
+    });
+  });
+};

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -24,6 +24,7 @@
 
 /* global MachineService, Machine, ConfigService */
 
+const adminId = 'aff17b8b-bf91-40bf-ace6-6dfc985680bb';
 const assert = require('chai').assert;
 const request = require('request-promise');
 const Promise = require('bluebird');
@@ -51,7 +52,7 @@ describe('Machine Service', () => {
           }
 
           return MachineService.getMachineForUser({
-            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+            id: adminId,
             name: 'Admin'
           })
             .then(() => {
@@ -88,7 +89,7 @@ describe('Machine Service', () => {
 
     it('Should return the same machine for a user', (done) => {
       MachineService.getMachineForUser({
-        id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        id: adminId,
         name: 'Admin'
       })
       .then((res) => {
@@ -96,7 +97,7 @@ describe('Machine Service', () => {
         const userMachine = res.id;
 
         MachineService.getMachineForUser({
-          id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+          id: adminId,
           name: 'Admin'
         })
         .then((res) => {
@@ -108,13 +109,28 @@ describe('Machine Service', () => {
       });
     });
 
+    it('Should return an inactive session', (done) => {
+      MachineService.getMachineForUser({
+        id: adminId,
+        name: 'Admin'
+      })
+      .then((machine) => {
+        return machine.getSessions();
+      })
+      .then((sessions) => {
+        assert.equal(sessions.length, 1);
+        assert.equal(sessions[0].state, 'Inactive');
+        return done();
+      });
+    });
+
     it('Opening a session should update machine endDate', (done) => {
       MachineService.sessionOpen({
-        id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb'
+        id: adminId
       })
       .then(() => {
         return MachineService.getMachineForUser({
-          id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+          id: adminId,
           name: 'Admin'
         })
         .then((machine) => {
@@ -131,16 +147,48 @@ describe('Machine Service', () => {
       });
     });
 
+    it('Should return an active session', (done) => {
+      MachineService.getMachineForUser({
+        id: adminId,
+        name: 'Admin'
+      })
+      .then((machine) => {
+        return machine.getSessions();
+      })
+      .then((sessions) => {
+        assert.equal(sessions.length, 1);
+        assert.equal(sessions[0].state, 'Active');
+        return done();
+      });
+    });
+
+    it('Should end the active session', (done) => {
+      MachineService.getMachineForUser({
+        id: adminId,
+        name: 'Admin'
+      })
+      .then((machine) => {
+        return machine.killSession()
+          .then(() => {
+            return machine.isSessionActive();
+          })
+        .then((active) => {
+          assert.isFalse(active);
+          return done();
+        });
+      });
+    });
+
     it('Should terminate machine if no connection occured after the maximum session duration time', (done) => {
       return MachineService.getMachineForUser({
-        id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
+        id: adminId,
         name: 'Admin'
       })
       .then((machine) => {
         return request('http://' + machine.ip + ':' + machine.plazaport + '/sessionClose')
         .then(() => {
           return MachineService.sessionEnded({
-            id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb'
+            id: adminId
           });
         })
         .then(() => {

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -67,7 +67,7 @@ describe('Machine Service', () => {
 
                       return resolve();
                     });
-                }, 10);
+                }, 100);
               });
             })
             .then(() => {
@@ -211,7 +211,7 @@ describe('Machine Service', () => {
             .then(() => {
               return done();
             });
-          }, 10); // Give broker time to cleanup instances
+          }, 100); // Give broker time to cleanup instances
         });
       });
     });


### PR DESCRIPTION
Add endpoints to list active windows sessions  and delete them.
- GET /api/sessions will fetch sessions states
- DELETE /api/sessions will kill current session on which user is connected
