### PR TITLE
Fix could not login with account created with signup

### DIFF
--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -105,7 +105,7 @@ module.exports = {
         if (!user) {
           return res.notFound('No user found');
         }
-        user.expirationDate = moment().add(expirationDays, 'days').unix();
+        user.expirationDate = (expirationDays) ? moment(new Date()).add(expirationDays, 'days').unix() : null;
         User.create(user)
           .then(() => {
             return PendingUser.destroy({


### PR DESCRIPTION
Fixes #113

Users registering with the signup form could not login because their accounts were wrongly considered expired.
