### PR TITLE
Fix reset-password not working because update required an access token

### DIFF
--- a/api/controllers/Reset-passwordController.js
+++ b/api/controllers/Reset-passwordController.js
@@ -22,20 +22,9 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-
-/**
- * Reset-passwordController
- *
- * @description :: Server-side logic for managing resetpasswords
- * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
- */
-
-/* globals ConfigService */
-/* globals EmailService */
-/* globals User */
+/* globals ConfigService, EmailService, User */
 
 const uuid          = require('node-uuid');
-const bcrypt        = require('bcryptjs');
 
 module.exports = {
   create: function(req, res) {
@@ -119,11 +108,10 @@ module.exports = {
         throw new Error('Password can not be empty');
       }
 
-      let hash = bcrypt.hashSync(dataReq.password, 10);
       return User.update({
         id: user.id
       }, {
-        hashedPassword: hash
+        password: dataReq.password
       });
     })
     // destroy the reset password token
@@ -134,7 +122,7 @@ module.exports = {
     })
     // return response
     .then(() => {
-      return res.ok({});
+      return res.json({meta: {}});
     })
     .catch((err) => {
       if (err.message === 'No user found') {

--- a/config/policies.js
+++ b/config/policies.js
@@ -65,7 +65,7 @@ module.exports.policies = {
   'Reset-passwordController': {
     create: true,
     update: true,
-    findOne: true,
+    findOne: true
   },
 
   HistoryController : {

--- a/config/routes.js
+++ b/config/routes.js
@@ -75,6 +75,11 @@ module.exports.routes = {
     action: 'update'
   },
 
+  'PATCH /api/reset-passwords/:id': {
+    controller: 'Reset-password',
+    action: 'update'
+  },
+
   'PATCH /api/:model/:id': {
     controller: 'Nanocloud',
     action: 'update'


### PR DESCRIPTION
Fixes https://github.com/Nanocloud/nanocloud/issues/116

Make sure PATCH /api/reset-passwords is accessible even without access tokens.
Rewrite test to check password update.
