### PR TITLE
Retrieve autoregister attribute as a property

### DIFF
--- a/api/controllers/PropertyController.js
+++ b/api/controllers/PropertyController.js
@@ -40,7 +40,7 @@ module.exports = {
   find(req, res) {
 
     ConfigService.get(
-      'title', 'favIconPath', 'logoPath', 'primaryColor'
+      'title', 'favIconPath', 'logoPath', 'primaryColor', 'autoRegister'
     )
     .then((config) => {
 
@@ -63,7 +63,8 @@ module.exports = {
         primaryColor: config.primaryColor,
         title: config.title,
         style: logo + sidebarColor,
-        favicon: favIcon
+        favicon: favIcon,
+        autoRegister: config.autoRegister
       });
     })
     .catch((err) => res.negotiate(err));

--- a/assets/app/initializers/properties.js
+++ b/assets/app/initializers/properties.js
@@ -36,6 +36,8 @@ export function initialize(app) {
     document.title = res.title;
     config.APP.name = res.title;
 
+    config.APP.autoRegister = res.autoRegister;
+
     $('title').text(res.title);
     let favicon = Ember.$('<link rel="shortcut icon">');
     favicon.attr('href', res.favicon);

--- a/assets/app/login/controller.js
+++ b/assets/app/login/controller.js
@@ -23,16 +23,19 @@
  */
 
 import Ember from 'ember';
+import config from 'nanocloud/config/environment';
 
 export default Ember.Controller.extend({
   identification: '',
   password: '',
   configuration: Ember.inject.service('configuration'),
 
+
   reset() {
     this.setProperties({
       identification: '',
-      password: ''
+      password: '',
+      autoRegister: config.APP.autoRegister
     });
   },
 

--- a/assets/app/login/template.hbs
+++ b/assets/app/login/template.hbs
@@ -9,7 +9,7 @@
 				{{input class='form-control' placeholder='Password' type='password' value=password}}
 			</fieldset>
 			<button type="submit" class="btn btn-primary btn-block text-uppercase">Login</button>
-			{{#if configuration.autoRegister}}
+			{{#if autoRegister}}
 				{{#link-to 'sign-up'}}Sign up{{/link-to}}
 			{{/if}}
 			{{#link-to 'reset-password' class="fright"}}Reset my password{{/link-to}}


### PR DESCRIPTION
The autoRegister attribute can now be retrieved as a property. The advantage is that properties are publicly accessible so the login page can display the sign-up link if the user as no token.
