### PR TITLE
Fix headers can be sent twice in authentication middlewares

### DIFF
--- a/api/policies/isAuthorized.js
+++ b/api/policies/isAuthorized.js
@@ -38,8 +38,14 @@ module.exports = function(req, res, next) {
 
   return passport.authenticate('bearer', function(err, user) {
 
-    if ((err) || (!user)) {
-      return res.send(401);
+    if (err) {
+      return next(err);
+    } else if (!user) {
+      return next({
+        error: 'access_denied',
+        error_description: 'Invalid User Credentials',
+        status: 401
+      });
     }
 
     delete req.query.access_token;

--- a/config/passport.js
+++ b/config/passport.js
@@ -63,10 +63,7 @@ passport.use(
             }
 
             if (!user) {
-              return done(
-                null, false, {
-                  message: 'Unknown user ' + username
-                });
+              return done(null, null);
             }
 
             bcrypt.compare(password, user.hashedPassword, function(err, res){

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "request": "^2.74.0",
     "request-promise": "^4.1.0",
     "sails": "~0.12.3",
-    "sails-json-api-blueprints": "0.11.6",
+    "sails-json-api-blueprints": "0.12.0",
     "sails-postgresql": "^0.11.4",
     "sails-seed": "^0.4.5",
     "sha1": "^1.1.1",

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -97,10 +97,10 @@ module.exports = function() {
         nano.request(sails.hooks.http.app)
           .get('/api/users')
           .expect(401)
-          .expect(function backendToRespondWithUnauthorized(res) {
-            if (res.text !== 'Unauthorized') {
-              throw new Error('API should respond with 401 Unauthorized if someone try to access /api/* with no access token');
-            }
+          .expect({
+            error: 'access_denied',
+            error_description: 'Invalid User Credentials',
+            status: 401
           })
           .end(done);
       });


### PR DESCRIPTION
Fixes https://github.com/Nanocloud/nanocloud/issues/124

Replace call to `res.send` to call to the next middleware with an error message. Plus add an error handler.
