### PR TITLE
Fix manual driver destroys machine

### DIFF
--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -256,12 +256,15 @@ function _createMachine() {
 }
 
 function _terminateMachine(machine) {
-  return Machine.destroy({
-    id: machine.id
-  })
-    .then(() => {
-      return _driver.destroyMachine(machine);
-    });
+
+  if (_driver.destroyMachine) {
+    return _driver.destroyMachine(machine)
+      .then(() => {
+        return Machine.destroy({
+          id: machine.id
+        });
+      });
+  }
 }
 
 /**
@@ -312,7 +315,12 @@ function _shouldTerminateMachine(machine) {
       if (!isActive) {
         const now = new Date();
         if (machine.endDate < now) {
-          _terminateMachine(machine);
+          machine.user = null;
+
+          Machine.update(machine.id, machine)
+            .then(() => {
+              _terminateMachine(machine);
+            });
         }
       }
     });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -76,11 +76,12 @@ module.exports = {
      *
      * Array of objects Machine:
      * {
-     *   name: "Machine name",
-     *   type: "manual",
-     *   ip: "0.0.0.0",
-     *   username: "Administrator",
-     *   password: "secret"
+     *   name: 'Machine name',
+     *   type: 'manual',
+     *   ip: '0.0.0.0',
+     *   username: 'Administrator',
+     *   password: 'secret',
+     *   plazaport: 9090
      * }
      */
     machines: [],


### PR DESCRIPTION
Fixes #144

Check if `destroyMachine` is implemented before trying to remove machine.
Remove `machine.user` when session is over after `sessionDuration`.
Modify `config/env/development` to add `plazaPort` in manual driver example.
