### PR TITLE
Consider machines to be up if they exist

### DIFF
--- a/assets/app/protected/dashboard/controller.js
+++ b/assets/app/protected/dashboard/controller.js
@@ -50,9 +50,7 @@ export default Ember.Controller.extend({
   }),
 
   machines: Ember.computed('model.machines', 'model.machines', function() {
-    var machines = this.get('model.machines')
-      .filterBy('status', 'up');
-    return machines;
+    return this.get('model.machines');
   }),
 
   activator: function() {


### PR DESCRIPTION
#52

There is currently no filter to do to determine if a machine is up. They are considered to be up if they exist at all.
