### PR TITLE
Fix wrong publication date for apps

### DIFF
--- a/assets/app/app/model.js
+++ b/assets/app/app/model.js
@@ -37,7 +37,7 @@ const Validations = buildValidations({
 
 export default DS.Model.extend(Validations, {
   state: DS.attr('string'),
-  publicationDate: DS.attr('string'),
+  createdAt: DS.attr('string'),
   groups: DS.hasMany('group'),
   alias: DS.attr('string'),
   collectionName: DS.attr('string'),

--- a/assets/app/protected/apps/app/template.hbs
+++ b/assets/app/protected/apps/app/template.hbs
@@ -13,7 +13,7 @@
       </tr>
       <tr>
         <th scope="row">Publication date</th>
-        <td>{{publicationDate}}</td>
+        <td>{{moment-calendar model.createdAt}}</td>
       </tr>
       <tr>
         <th scope="row">


### PR DESCRIPTION
Fixes #145 

Front-end variable name don't matche with back-end variable name:
Change publicationDate to createdAt.
