### PR TITLE
Add comprehensive message for expired account at login

### DIFF
--- a/assets/app/login/controller.js
+++ b/assets/app/login/controller.js
@@ -48,8 +48,12 @@ export default Ember.Controller.extend({
         'authenticator:oauth2',
         identification,
         password
-      ).catch(() => {
-        this.toast.error('Invalid credentials');
+      ).catch((err) => {
+        if (err.error_description === 'This account is expired') {
+          this.toast.error('This account is expired');
+        } else {
+          this.toast.error('Invalid credentials');
+        }
       });
     }
   }

--- a/config/oauth2.js
+++ b/config/oauth2.js
@@ -36,22 +36,10 @@ server.exchange(oauth2orize.exchange.password(function(user, username, password,
 
   User.findOne({
     email: username,
-    or: [
-      { expirationDate: { '>' : Math.floor(new Date() / 1000)  } },
-      { expirationDate: null },
-      { expirationDate: 0 }
-    ]
   }, function(err, user) {
 
     if (err) {
       done(err);
-    }
-    if (!user) {
-      return done({
-        error: 'access_denied',
-        error_description: 'Invalid User Credentials',
-        status: 400
-      });
     }
 
     // delete reset password tokens

--- a/config/passport.js
+++ b/config/passport.js
@@ -68,10 +68,20 @@ passport.use(
 
             bcrypt.compare(password, user.hashedPassword, function(err, res){
               if(err){
-                return done(err, null);
+                return done(err);
               } else {
                 if (!res) {
-                  return done( null, false, { message: 'Invalid password' });
+                  return done({
+                    error: 'access_denied',
+                    error_description: 'Invalid user credentials',
+                    status: 400
+                  });
+                } else if (user.expirationDate < Math.floor(new Date() / 1000) && user.expirationDate !== null) {
+                  return done({
+                    error: 'access_denied',
+                    error_description: 'This account is expired',
+                    status: 400
+                  });
                 } else {
                   return done(null, user);
                 }

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -1371,6 +1371,26 @@ paths:
           schema:
             $ref: "#/definitions/Properties"
 
+  /oauth/token:
+    get:
+      tags:
+        - oauth
+      summary:
+        Return a token from a valid username/password
+      parameters:
+        - in: body
+          name: data
+          description: Login credentials
+          required: true
+          schema:
+            $ref: "#/definitions/Login"
+      responses:
+        400:
+          description: Your credentials are not valid or your account expired
+          schema:
+            $ref: "#/definitions/LoginErrors"
+
+
 definitions:
   Configuration:
     type: object
@@ -1939,3 +1959,23 @@ definitions:
         type: string
       autoRegister:
         type: boolean
+
+  Login:
+    type: object
+    properties:
+      username:
+        type: string
+      password:
+        type: string
+      grant_type:
+        type: string
+
+  LoginErrors:
+    type: object
+    properties:
+      error:
+        type: string
+      error_description:
+        type: string
+      status:
+        type: number

--- a/tests/api/user-limitation.test.js
+++ b/tests/api/user-limitation.test.js
@@ -98,7 +98,7 @@ module.exports = function() {
           .end(done);
       });
 
-      it('Should return login error', function(done) {
+      it('Should return the expired account error message', function(done) {
         nano.request(sails.hooks.http.app)
           .post('/oauth/token')
           .send({
@@ -107,6 +107,12 @@ module.exports = function() {
             grant_type: 'password'
           })
           .set('Authorization', 'Basic ' + new Buffer('9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341').toString('base64'))
+          .expect(400)
+          .expect((res) => {
+            if (res.body.error_description !== 'This account is expired') {
+              throw new Error('Error message is not appropriate');
+            }
+          })
           .end(done);
       });
     });


### PR DESCRIPTION
Fixes #118 

Add comprehensive error message for expired account. Now we ckeck in localStrategy instead in oauth.
