### PR TITLE
Fix admin could not update user profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "request": "^2.74.0",
     "request-promise": "^4.1.0",
     "sails": "~0.12.3",
-    "sails-json-api-blueprints": "0.12.0",
+    "sails-json-api-blueprints": "0.12.1",
     "sails-postgresql": "^0.11.4",
     "sails-seed": "^0.4.5",
     "sha1": "^1.1.1",

--- a/tests/api/users.test.js
+++ b/tests/api/users.test.js
@@ -100,6 +100,11 @@ module.exports = function() {
                     'expiration-date': null,
                     password: 'essai'
                   },
+                  relationships: {
+                    team: {
+                      data: null
+                    }
+                  },
                   type: 'users',
                   id: user.id,
                 }


### PR DESCRIPTION
Fixes #159

Update sails-json-api-blueprints to 0.12.1 to fix a bug were not support one way relationship were still trying to be handled.
Add test to validate this behavior.
