### PR TITLE
Fix storage-team could not start in production mode

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -1,0 +1,32 @@
+version: '2'
+
+services:
+  storage-team:
+    build: ./storage
+    image: nanocloud/storage
+    environment:
+     - PLAZA_PORT=9091
+    ports:
+     - 445/udp:445/udp
+     - 445:445
+     - 9091:9091
+    networks:
+      - nanocloud
+    depends_on:
+      - plaza
+    volumes:
+      - plaza:/opt/plaza
+    restart: always
+
+  plaza:
+    extends:
+      file: docker-compose.yml
+      service: plaza
+
+networks:
+  nanocloud:
+    driver: bridge
+
+volumes:
+  plaza:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,23 +56,6 @@ services:
       - plaza:/opt/plaza
     restart: always
 
-  storage-team:
-    build: ./storage
-    image: nanocloud/storage
-    environment:
-     - PLAZA_PORT=9091
-    ports:
-     - 445/udp:445/udp
-     - 445:445
-     - 9091:9091
-    networks:
-      - nanocloud
-    depends_on:
-      - plaza
-    volumes:
-      - plaza:/opt/plaza
-    restart: always
-
   plaza:
     build: ./plaza
     image: nanocloud/plaza


### PR DESCRIPTION
Both storage and storage-team use the same ports. In production mode those servers needs to be on different host.
As such, the two containers have been seprated in a two different docker-compose file.

Storage-team as an optional feature have been placed in a docker-compose-extra.yml package
