### PR TITLE
Fix logo not displayed in production mode

### DIFF
--- a/assets/ember-cli-build.js
+++ b/assets/ember-cli-build.js
@@ -30,6 +30,9 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     // Add options here
 
+    fingerprint: {
+      exclude: ['logo']
+    },
     emberCliFontAwesome: {
       useScss: true, // for ember-cli-sass
       useLess: false // for ember-cli-less


### PR DESCRIPTION
Fixes #167

In production mode, Ember appends a fingerprint to all assets to avoid caching issue.
This works fine, but since the path to the logo in stored statically in the database as a property, the path needs to be fixed.
This fix disable fingerprinting for the logo.
