### PR TITLE
Bugfix: Team Tab is always up for regular user

### DIFF
--- a/assets/app/protected/template.hbs
+++ b/assets/app/protected/template.hbs
@@ -68,14 +68,16 @@
           {{/unless}}
 
           {{#unless session.user.isAdmin}}
-            <li>
-                {{#link-to 'protected.users.teams'}}
-                <span class="icon">
-                    <i class="material-icons">assignment_ind</i>
-                </span>
-                Team
-                {{/link-to}}
-            </li>
+            {{#if teamEnabled}}
+              <li>
+                  {{#link-to 'protected.users.teams'}}
+                  <span class="icon">
+                      <i class="material-icons">assignment_ind</i>
+                  </span>
+                  Team
+                  {{/link-to}}
+              </li>
+            {{/if}}
           {{/unless}}
 
           {{#if session.user.isAdmin}}


### PR DESCRIPTION
Team tab was always visible to regular users because we didn't check whether the team option is enabled or not.
Fixes #183 
