### PR TITLE
Fix Permission denied on Configuration tab for Administrator

### DIFF
--- a/assets/app/protected/configs/route.js
+++ b/assets/app/protected/configs/route.js
@@ -32,7 +32,7 @@ export default Ember.Route.extend({
     });
   },
   beforeModel() {
-    if (!this.get('session.user.isAdmin')) {
+    if (!this.get('session').get('user').get('isAdmin')) {
       this.toast.error('Permission denied');
       this.transitionTo('protected.dashboard');
     }


### PR DESCRIPTION
Fixes #182

Strangely, `this.get('session.user.isAdmin')` returned undefined even though session.user was correctly set.
Replacing with working `this.get('session').get('user').get('isAdmin')`
