### PR TITLE
Use email templating for reset password email

### DIFF
--- a/api/views/reset-password-email.hbs
+++ b/api/views/reset-password-email.hbs
@@ -1,0 +1,4 @@
+Hello {{firstName}} {{lastName}},<br/>
+We received a request to reset your password.<br/>
+<a href="{{resetLink}}">Reset my password</a><br/><br/>
+<i>If you ignore this message your password won't be changed.</i>


### PR DESCRIPTION
Fixes #189 

Use the email templating for reset password like we use it for pending-user.
Create a template file `reset-password-email.hbs` for reset password email 
