### PR TITLE
Allow to specify administrator's password for custom AWS ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ AWS driver specific:
 - awsImage (Defaults to ami-09e61366) Nanocloud's execution servers default image)
 - awsFlavor (Defaults to t2.medium) size of virtual machines
 - awsMachineUsername (Defaults to Administrator) administrator account on the machine
+- awsMachinePassword (Defaults to empty string, will be generated if possible) administrator password on the machine
 - creditLimit (Defaults empty string) set a credit limit to users (aws only)
 
 Openstack driver specific:

--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -49,6 +49,7 @@ class AWSDriver extends Driver {
    *  - awsKeyName: The AWS key pair name to use or create
    *  - awsPrivateKey: The location of the AWS private key to use or create
    *  - awsImage: The image to build Nanocloud executation servers from
+   *  - awsMachinePassword: The password associated with the administrator account
    *
    * @method initialize
    * @return {Promise}
@@ -56,7 +57,7 @@ class AWSDriver extends Driver {
   initialize() {
     return ConfigService.get(
       'awsAccessKeyId', 'awsSecretAccessKey', 'awsRegion',
-      'awsKeyName', 'awsPrivateKey', 'awsImage'
+      'awsKeyName', 'awsPrivateKey', 'awsImage', 'awsMachinePassword'
     )
       .then((config) => {
         this._client = pkgcloud.compute.createClient({
@@ -105,7 +106,8 @@ class AWSDriver extends Driver {
               default: true
             }, {
               iaasId: config.awsImage,
-              name: 'AWS default'
+              name: 'AWS default',
+              password: config.awsMachinePassword || null
             });
           });
       });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -100,6 +100,7 @@ module.exports = {
     awsImage: 'ami-09e61366',
     awsFlavor: 't2.medium',
     awsMachineUsername: 'Administrator',
+    awsMachinePassword: '',
 
     openstackUsername:  '',
     openstackPassword: '',


### PR DESCRIPTION
Fixes #185

While it was possible to specify a custom AMI to use as default image, the default generating password strategy would not work.
This fixes it by adding a new `awsMachinePassword` variable to specify the default password if any.
