### PR TITLE
Use private ip address on AWS if public address is not available

### DIFF
--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -312,7 +312,7 @@ class AWSDriver extends Driver {
                 const server = res.server;
                 const password = res.password;
                 const image = res.image;
-                const ip = server.addresses.public[0];
+                const ip = server.addresses.public[0] || server.addresses.private[0];
                 const type = this.name();
 
                 return ConfigService.get('awsMachineUsername', 'plazaPort', 'awsFlavor')


### PR DESCRIPTION
Fixes #184

This will only work if both Nanocloud and execution instances are on AWS.
