### PR TITLE
Allow to specify subnet id to apply to machines on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ AWS driver specific:
 - awsFlavor (Defaults to t2.medium) size of virtual machines
 - awsMachineUsername (Defaults to Administrator) administrator account on the machine
 - awsMachinePassword (Defaults to empty string, will be generated if possible) administrator password on the machine
+- awsMachineSubnet (Defaults to empty string, automatic subnet) subnet to assign to the machine
 - creditLimit (Defaults empty string) set a credit limit to users (aws only)
 
 Openstack driver specific:

--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -220,6 +220,7 @@ class AWSDriver extends Driver {
    *  - plazaURI: The URL from where the instance will download plaza.exe
    *  - awsKeyName: The name of the KeyPair to use for the instance admin
    *  - plazaPort: Port to contact plaza
+   *  - awsMachineSubnet: Subnet's id to apply to machines
    *
    * @method createMachine
    * @param {Object} options The machine options. `options.name`: The name of
@@ -227,7 +228,7 @@ class AWSDriver extends Driver {
    * @return {Promise[Machine]} The created machine
    */
   createMachine(options) {
-    return ConfigService.get('awsFlavor', 'plazaURI', 'awsKeyName', 'plazaPort')
+    return ConfigService.get('awsFlavor', 'plazaURI', 'awsKeyName', 'plazaPort', 'awsMachineSubnet')
       .then((config) => {
 
         return MachineService.getDefaultImage()
@@ -249,7 +250,8 @@ class AWSDriver extends Driver {
                 image    : image.iaasId,
                 flavor   : config.awsFlavor,
                 KeyName  : config.awsKeyName,
-                UserData : userData
+                UserData : userData,
+                subnetId : config.awsMachineSubnet
               }, (err, server) => {
                 if (err) {
                   return reject(err);

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -101,6 +101,7 @@ module.exports = {
     awsFlavor: 't2.medium',
     awsMachineUsername: 'Administrator',
     awsMachinePassword: '',
+    awsMachineSubnet: '',
 
     openstackUsername:  '',
     openstackPassword: '',


### PR DESCRIPTION
Fixes https://github.com/Nanocloud/nanocloud/issues/200

This relies on code modification proposed in Pkgcloud forked by Nanocloud here: https://github.com/Nanocloud/pkgcloud/pull/1
