### PR TITLE
Fix code live reload not working in dev mode

### DIFF
--- a/assets/Dockerfile-dev
+++ b/assets/Dockerfile-dev
@@ -4,4 +4,4 @@ MAINTAINER Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 CMD npm install && \
     bower install --allow-root && \
     ember build --environment=development && \
-    ember serve
+    ember serve --insecure-proxy true --ssl true --ssl-key /opt/ssl/nginx.key --ssl-cert /opt/ssl/nginx.crt

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -20,6 +20,7 @@ services:
     image: nanocloud/frontend:dev
     volumes:
       - ./assets:/opt
+      - ./proxy/certificates:/opt/ssl/:ro
     network_mode: host
     container_name: "frontend"
 


### PR DESCRIPTION
Fixes #154

Since all requests are https requests proxied by nginx, live reload server needed to be ssl secured as well.
This fix run the ember server with the same https credentials as nginx in dev mode.
