### PR TITLE
Init config function do not overwrite config after first up

### DIFF
--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -272,6 +272,7 @@ function set(key, value) {
 /**
  * init initializes the ConfigService. It will copy the configuration variables
  * found in `config.nanocloud` in the database.
+ * init do not overwrite values that already exist.
  *
  * @method init
  * @private
@@ -282,11 +283,19 @@ function init(callback) {
   const config = sails.config.nanocloud;
   let actions = [];
 
-  for (let name in config) {
+  Object.keys(config).forEach((name) => {
     if (config.hasOwnProperty(name)) {
-      actions.push(set(name, nanocloudConfigValue(name, config[name])));
+      actions.push(Config.findOne({
+        key: name
+      })
+      .then((conf) => {
+        if (!conf || conf.value === '') {
+          return set(name, nanocloudConfigValue(name, config[name]));
+        }
+      })
+      );
     }
-  }
+  });
 
   return Promise.all(actions).then(callback, callback);
 }


### PR DESCRIPTION
Fixes #168 
Init config function do not overwrite config values that already exists anymore.
If the config key doesn't exist in config table init function create it.
