### PR TITLE
Use a unique token to activate pending user account

### DIFF
--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -40,6 +40,7 @@ module.exports = {
 
     user.id = uuid.v4();
     user.isAdmin = false;
+    user.token = uuid.v4();
 
     ConfigService.get('autoRegister')
       .then((conf) => {
@@ -76,7 +77,7 @@ module.exports = {
         return TemplateService.render('activation-email', {
           firstName: user['first-name'],
           lastName: user['last-name'],
-          activationLink: `http://${host}/#/activate/${user.id}`
+          activationLink: `http://${host}/#/activate/${user.token}`
         })
           .then((message) => {
             return EmailService.sendMail(to, subject, message)
@@ -108,14 +109,14 @@ module.exports = {
   },
 
   update: function(req, res) {
-    var pendingUserID = req.params.id;
+    var pendingUserToken = req.params.id;
     var expirationDays;
 
     ConfigService.get('expirationDate')
       .then((conf) => {
         expirationDays = conf.expirationDate;
         return PendingUser.findOne({
-          id: pendingUserID
+          token: pendingUserToken
         });
       })
       .then((user) => {
@@ -141,7 +142,7 @@ module.exports = {
           })
           .then(() => {
             return PendingUser.destroy({
-              id: pendingUserID
+              token: pendingUserToken
             });
           })
           .then(() => {

--- a/api/migrations/020_add_token_column_in_pendinguser.js
+++ b/api/migrations/020_add_token_column_in_pendinguser.js
@@ -1,0 +1,35 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex) {
+  return knex.schema.table('pendinguser', (table) => {
+    table.string('token');
+  });
+}
+
+function down(knex) {
+  return knex.schema.dropColumn('pendinguser');
+}
+
+module.exports = { up, down };

--- a/api/models/PendingUser.js
+++ b/api/models/PendingUser.js
@@ -67,9 +67,14 @@ module.exports = {
       model: 'team'
     },
 
+    token: {
+      type: 'string'
+    },
+
     toJSON: function() {
       var obj = this.toObject();
       delete obj.hashedPassword;
+      delete obj.token;
       return obj;
     }
   },

--- a/tests/api/auto-signup.test.js
+++ b/tests/api/auto-signup.test.js
@@ -22,7 +22,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* globals sails, User, ConfigService, Group, UserGroup */
+/* globals sails, User, ConfigService, Group, UserGroup, PendingUser */
 
 var nano = require('./lib/nanotest');
 var expect = require('chai').expect;
@@ -91,10 +91,15 @@ module.exports = function() {
             });
         })
         .then((res) => {
+          return PendingUser.findOne({
+            email: res.body.data[0].attributes.email
+          });
+        })
+        .then((res) => {
 
           // activate user
           return nano.request(sails.hooks.http.app)
-            .patch('/api/pendingusers/' + res.body.data[0].id)
+            .patch('/api/pendingusers/' + res.token)
             .expect(200)
             .expect(nano.jsonApiSchema(expectedSchema));
         })
@@ -131,10 +136,15 @@ module.exports = function() {
             })
             .expect(201)
             .then((res) => {
+              return PendingUser.findOne({
+                email: res.body.data.attributes.email
+              });
+            })
+            .then((res) => {
 
               // activate user
               return nano.request(sails.hooks.http.app)
-                .patch('/api/pendingusers/' + res.body.data.id)
+                .patch('/api/pendingusers/' + res.token)
                 .expect(200)
                 .expect(nano.jsonApiSchema(expectedSchema));
             })
@@ -172,10 +182,15 @@ module.exports = function() {
             })
             .expect(201)
             .then((res) => {
+              return PendingUser.findOne({
+                email: res.body.data.attributes.email
+              });
+            })
+            .then((res) => {
 
               // activate user
               return nano.request(sails.hooks.http.app)
-                .patch('/api/pendingusers/' + res.body.data.id)
+                .patch('/api/pendingusers/' + res.token)
                 .expect(200)
                 .expect(nano.jsonApiSchema(expectedSchema));
             })
@@ -258,9 +273,9 @@ module.exports = function() {
             groupId = group.id;
             return ConfigService.set('defaultGroup', groupId);
           })
-					.then(() => {
-						return ConfigService.set('autoRegister', true);
-					})
+          .then(() => {
+            return ConfigService.set('autoRegister', true);
+          })
           .then(() => {
             return done();
           });
@@ -295,9 +310,14 @@ module.exports = function() {
           })
           .expect(201)
           .then((res) => {
+            return PendingUser.findOne({
+              email: res.body.data.attributes.email
+            });
+          })
+          .then((res) => {
             // activate user
             return nano.request(sails.hooks.http.app)
-              .patch('/api/pendingusers/' + res.body.data.id)
+              .patch('/api/pendingusers/' + res.token)
               .expect(200)
               .expect(nano.jsonApiSchema(expectedSchema));
           })
@@ -315,34 +335,34 @@ module.exports = function() {
       });
     });
 
-		it('Should not create an entry in pending user table', function(done) {
+    it('Should not create an entry in pending user table', function(done) {
 
-			ConfigService.set('autoRegister', false)
-				.then(() => {
-					// adding user to pendinguser table
-					nano.request(sails.hooks.http.app)
-						.post('/api/pendingusers')
-						.send({
-							data: {
-								attributes: userData,
-								type: 'pendingusers'
-							}
-						})
-						.expect(400)
-						.then (() => {
-							return done();
-						});
-				});
-		});
+      ConfigService.set('autoRegister', false)
+        .then(() => {
+          // adding user to pendinguser table
+          nano.request(sails.hooks.http.app)
+            .post('/api/pendingusers')
+            .send({
+              data: {
+                attributes: userData,
+                type: 'pendingusers'
+              }
+            })
+            .expect(400)
+            .then (() => {
+              return done();
+            });
+        });
+    });
 
     after(function(done) {
       ConfigService.unset('testMail')
         .then(() => {
-					return ConfigService.set('autoRegister', true);
+          return ConfigService.set('autoRegister', true);
         })
-				.then(() => {
-					return done();
-				});
+        .then(() => {
+          return done();
+        });
     });
 
     afterEach(function(done) {

--- a/tests/api/security.test.js
+++ b/tests/api/security.test.js
@@ -24,6 +24,7 @@
 
 /* globals sails, User, AccessToken, MachineService, Group */
 /* globals ConfigService, StorageService, Machine, Team, BrokerLog */
+/* globals PendingUser */
 
 const nano = require('./lib/nanotest');
 
@@ -1351,6 +1352,9 @@ module.exports = function() {
 
     describe('Pending-user', function() {
 
+      let adminPendingUserToken = null;
+      let ruPendingUserToken = null;
+      let nologPendingUserToken = null;
       let adminPendingUser = null;
       let ruPendingUser = null;
       let nologPendingUser = null;
@@ -1372,11 +1376,19 @@ module.exports = function() {
                 type: 'pendingusers'
               }
             })
-            .expect((res) => {
-              adminPendingUser = res.body.data.id;
-            })
             .expect(201)
-            .end(done);
+            .then((res) => {
+              return PendingUser.findOne({
+                id: res.body.data.id
+              });
+            })
+            .then((res) => {
+              adminPendingUserToken = res.token;
+              adminPendingUser = res.id;
+            })
+            .then(() => {
+              return done();
+            });
         });
 
         it('Regular users should be authorized to create a pending user', function(done) {
@@ -1394,11 +1406,19 @@ module.exports = function() {
                 type: 'pendingusers'
               }
             })
-            .expect((res) => {
-              ruPendingUser = res.body.data.id;
-            })
             .expect(201)
-            .end(done);
+            .then((res) => {
+              return PendingUser.findOne({
+                id: res.body.data.id
+              });
+            })
+            .then((res) => {
+              ruPendingUserToken = res.token;
+              ruPendingUser = res.id;
+            })
+            .then(() => {
+              return done();
+            });
         });
 
         it('Not logged in user should be authorized to create a pending user', function(done) {
@@ -1415,11 +1435,19 @@ module.exports = function() {
                 type: 'pendingusers'
               }
             })
-            .expect((res) => {
-              nologPendingUser = res.body.data.id;
-            })
             .expect(201)
-            .end(done);
+            .then((res) => {
+              return PendingUser.findOne({
+                id: res.body.data.id
+              });
+            })
+            .then((res) => {
+              nologPendingUserToken = res.token;
+              nologPendingUser = res.token;
+            })
+            .then(() => {
+              return done();
+            });
         });
       });
 
@@ -1505,7 +1533,7 @@ module.exports = function() {
 
         it('Admins should be authorized to activate a pending user', function(done) {
           return nano.request(sails.hooks.http.app)
-            .patch('/api/pendingusers/' + adminPendingUser)
+            .patch('/api/pendingusers/' + adminPendingUserToken)
             .set(nano.adminLogin())
             .expect(200)
             .end(done);
@@ -1513,7 +1541,7 @@ module.exports = function() {
 
         it('Regular users should be authorized to activate a pending user', function(done) {
           return nano.request(sails.hooks.http.app)
-            .patch('/api/pendingusers/' + ruPendingUser)
+            .patch('/api/pendingusers/' + ruPendingUserToken)
             .set('Authorization', 'Bearer ' + token)
             .expect(200)
             .end(done);
@@ -1521,7 +1549,7 @@ module.exports = function() {
 
         it('Not logged in user should be authorized to activate a pending user', function(done) {
           return nano.request(sails.hooks.http.app)
-            .patch('/api/pendingusers/' + nologPendingUser)
+            .patch('/api/pendingusers/' + nologPendingUserToken)
             .expect(200)
             .end(done);
         });

--- a/tests/api/team.test.js
+++ b/tests/api/team.test.js
@@ -23,7 +23,7 @@
  */
 
 // jshint mocha:true
-/* globals sails, AccessToken, ConfigService, User, Team */
+/* globals sails, AccessToken, ConfigService, User, Team, PendingUser */
 
 var nano = require('./lib/nanotest');
 var expect = require('chai').expect;
@@ -63,6 +63,7 @@ module.exports = function() {
     let teamAdmin = null;
     let teamAdminToken = null;
     let teamMemberId = null;
+    let teamMemberToken = null;
     let teamId = null;
 
     before((done) => {
@@ -159,7 +160,12 @@ module.exports = function() {
           .expect(201)
           .expect(nano.jsonApiSchema(userExpectedSchema))
           .then((res) => {
-            teamMemberId = res.body.data.id;
+            return PendingUser.findOne({
+              id: res.body.data.id
+            });
+          })
+          .then((res) => {
+            teamMemberToken = res.token;
             // user has been added to pending user table
             return nano.request(sails.hooks.http.app)
               .get('/api/pendingusers')
@@ -169,7 +175,7 @@ module.exports = function() {
           .then(() => {
             // activate user
             return nano.request(sails.hooks.http.app)
-              .patch('/api/pendingusers/' + teamMemberId)
+              .patch('/api/pendingusers/' + teamMemberToken)
               .expect(200);
           })
           .then((res) => {


### PR DESCRIPTION
Fixes #45 
Don't use pending user id to activate pending user anymore.
Instead using a random token added in pending user table.

Update tests using pending user activation.
