### PR TITLE
Machine's password is not returned when calling GET on /machines

### DIFF
--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -76,6 +76,12 @@ module.exports = {
       type: 'string'
     },
 
+    toJSON: function() {
+      var obj = this.toObject();
+      delete obj.password;
+      return obj;
+    },
+
     setEndDate(duration) {
       let now = (new Date()).getTime();
       let endDate = new Date(now + duration * 1000);


### PR DESCRIPTION
This PR fixes #37.
Delete password from response using toJSON function in machine model.
