### PR TITLE
Machines appear in booting state while starting

### DIFF
--- a/api/drivers/driver.js
+++ b/api/drivers/driver.js
@@ -86,6 +86,7 @@ class Driver {
   createImage(/* image */) {
     return Promise.reject(new Error('Driver\'s method "createImage" not implemented'));
   }
+
   /**
    * Calculate credit used by a user
    *
@@ -95,6 +96,28 @@ class Driver {
    */
   getUserCredit(/* user */) {
     return Promise.reject(new Error('Driver\'s method \'getUserCredit\' not implemented'));
+  }
+
+  /**
+   * Refresh machine's data
+   *
+   * @method refresh
+   * @param {Object} Machine model
+   * @return {Promise[Machine]}
+   */
+  refresh(/* machine */) {
+    return Promise.reject(new Error('Driver\'s method \'refresh\' not implemented'));
+  }
+
+  /**
+   * Retrieve machine's password
+   *
+   * @method getPassword
+   * @param {Object} Machine model
+   * @return {Promise[String]}
+   */
+  getPassword(/* machine */) {
+    return Promise.reject(new Error('Driver\'s method \'getPassword\' not implemented'));
   }
 }
 

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -133,22 +133,20 @@ class DummyDriver extends BaseDriver {
    * @return {Promise[Machine]} Machine model created
    */
   createMachine(options) {
-    let machine = {};
     const id = uuid.v4();
-
-    machine.id = id;
-    machine.name = options.name;
-    machine.type = 'dummy';
-    machine.flavor = 'dummy';
-    machine.ip = _plazaAddress;
-    machine.username = 'Administrator';
-    machine.plazaport = _plazaPort;
+    let machine = new Machine._model({
+      id        : id,
+      name      : options.name,
+      type      : 'dummy',
+      flavor    : 'dummy',
+      ip        : _plazaAddress,
+      username  : 'Administrator',
+      plazaport : _plazaPort,
+      domain    : ''
+    });
 
     this._machines[machine.id] = machine;
-    return new Promise((resolve, reject) => {
-      Machine.create(machine)
-        .then(resolve, reject);
-    });
+    return new Promise.resolve(machine);
   }
 
   destroyMachine(machine) {
@@ -232,6 +230,39 @@ class DummyDriver extends BaseDriver {
             return reject(err);
           });
       });
+    });
+  }
+
+  /**
+   * Retrieve the machine's data
+   *
+   * @method refresh
+   * @param {machine} Machine model
+   * @return {Promise[Machine]}
+   */
+  refresh(machine) {
+    return new Promise((resolve, reject) => {
+      if (machine.status === 'error') {
+        reject(machine.status);
+      }
+      machine.status = 'running';
+      return resolve(machine);
+    });
+  }
+
+  /**
+   * Retrieve the machine's password
+   *
+   * @method getPassword
+   * @param {machine} Machine model
+   * @return {Promise[String]}
+   */
+  getPassword(machine) {
+    return new Promise((resolve, reject) => {
+      if (machine.status === 'error') {
+        reject(machine.status);
+      }
+      return resolve(machine.password);
     });
   }
 }

--- a/api/migrations/021_add_status_machine.js
+++ b/api/migrations/021_add_status_machine.js
@@ -1,0 +1,38 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex) {
+  return knex.schema.table('machine', function(t) {
+    t.string('status');
+  });
+}
+
+function down(knex) {
+  return knex.schema.table('machine', function(t) {
+    t.dropColumn('status');
+  });
+}
+
+module.exports = { up, down };
+

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global Machine */
+/* global Machine, MachineService */
 
 const url = require('url');
 const Promise = require('bluebird');
@@ -70,6 +70,9 @@ module.exports = {
     user: {
       model: 'user',
       unique: true
+    },
+    status: {
+      type: 'string'
     },
 
     setEndDate(duration) {
@@ -166,6 +169,26 @@ module.exports = {
 
           return Promise.resolve();
         });
+    },
+
+    /**
+     * Retrieve the machine's data
+     *
+     * @method refresh
+     * @return {Promise[Machine]}
+     */
+    refresh() {
+      return MachineService.refresh(this);
+    },
+
+    /**
+     * Retrieve the machine's password
+     *
+     * @method getPassword
+     * @return {Promise[String]}
+     */
+    getPassword() {
+      return MachineService.getPassword(this);
     }
   }
 };

--- a/assets/app/machine/model.js
+++ b/assets/app/machine/model.js
@@ -35,6 +35,7 @@ export default DS.Model.extend({
     return this.get('status') === 'up';
   }),
   endDate: DS.attr('date'),
+  status: DS.attr('string'),
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
   expiration: Ember.computed('endDate', function() {

--- a/assets/app/protected/dashboard/controller.js
+++ b/assets/app/protected/dashboard/controller.js
@@ -50,7 +50,7 @@ export default Ember.Controller.extend({
   }),
 
   machines: Ember.computed('model.machines', 'model.machines', function() {
-    return this.get('model.machines');
+    return this.get('model.machines').filterBy('status', 'running');
   }),
 
   activator: function() {

--- a/assets/app/protected/machines/index/controller.js
+++ b/assets/app/protected/machines/index/controller.js
@@ -55,6 +55,7 @@ export default Ember.Controller.extend({
         id: item.get('id'),
         ip: item.get('ip'),
         expiration: item.get('expiration'),
+        status: item.get('status'),
         user: item.get('user'),
         endDate: item.get('endDate'),
       }));
@@ -68,6 +69,13 @@ export default Ember.Controller.extend({
       propertyName: 'id',
       title: 'ID',
       disableFiltering: true,
+    },
+    {
+      propertyName: 'boot',
+      title: 'Status',
+      disableFiltering: true,
+      filterWithSelect: false,
+      template: 'protected/machines/index/table/machine-list/boot',
     },
     {
       propertyName: 'name',

--- a/assets/app/protected/machines/index/table/machine-list/boot/template.hbs
+++ b/assets/app/protected/machines/index/table/machine-list/boot/template.hbs
@@ -1,2 +1,1 @@
-{{state-machine record.status}}
-{{light-bulb class='in-bl va-bottom px-l-5' enabled=true status=record.status}}
+{{light-bulb class='in-bl va-bottom px-l-5' content=record.status currentStatus=record.status}}

--- a/assets/app/styles/light-bulb.scss
+++ b/assets/app/styles/light-bulb.scss
@@ -6,50 +6,50 @@
     height: 20px;
     border-radius: 10px;
 
-    &.unknown {		
-      background-color: #F45835;		
+    &.unknown {
+      background-color: #F45835;
       box-shadow: 0px 0px 1px #F45835;
-    }		
+    }
 
-    &.down {		
-      background-color: #dedede;		
+    &.down {
+      background-color: #dedede;
       box-shadow: 0px 0px 1px #a0a0a0;
-    }		
+    }
 
-    &.up {		
+    &.running {
       background-color: #5eca20;
       box-shadow: 0px 0px 1px #5eca20;
-    }		
+    }
 
-    &.terminated {		
-      background-color: #525252;		
+    &.terminated {
+      background-color: #525252;
       box-shadow: 0px 0px 1px #525252;
-    }		
+    }
 
-    &.reboot {		
+    &.reboot {
       @extend .booting;
-    }		
+    }
 
-    &.booting {		
+    &.booting {
       background-color: #F4B835;
       box-shadow: 0px 0px 1px #F4B835;
       @extend .transition-enabled;
       animation-name: nanoloading;
       animation-duration: 2s;
       animation-iteration-count: infinite;
-    }		
+    }
 
-    &.stopping {		
+    &.stopping {
       background-color: red;
       box-shadow: 0px 0px 1px red;
       @extend .transition-enabled;
       animation-name: nanoloading;
       animation-duration: 2s;
       animation-iteration-count: infinite;
-    }		
+    }
 
-    &.downloading {		
-      background-color: #8EDAFB;		
+    &.downloading {
+      background-color: #8EDAFB;
       box-shadow: 0px 0px 1px #8EDAFB;
     }
   }

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -1789,6 +1789,8 @@ definitions:
             type: string
           user:
             type: string
+          status:
+            type: string
 
   AccessToken:
     type: object

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "passport-local": "^1.0.0",
     "pg": "^6.1.0",
     "pkgcloud": "git+https://github.com/Nanocloud/pkgcloud.git",
+    "promise-poller": "^1.5.0",
     "randomstring": "^1.1.5",
     "rc": "1.0.1",
     "request": "^2.74.0",

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -108,7 +108,9 @@ describe('Machine Service', () => {
                   assert.equal(machineLogs[0].machineFlavor, 'dummy');
                   return BrokerLog.find({
                     userId: null,
-                    state: 'Update machine pool'
+                    state: {
+                      like: '%Update machine pool%'
+                    }
                   });
                 })
                 .then((logs) => {
@@ -116,7 +118,7 @@ describe('Machine Service', () => {
                     throw new Error('Broker should log when machine pool need to be update');
                   }
                   assert.isNull(logs[0].machineId);
-                  assert.equal(logs[0].state, 'Update machine pool');
+                  assert.equal(logs[0].state, 'Update machine pool from 0 to 1 (+1)');
                   assert.equal(logs[0].machineDriver, 'dummy');
                 })
                 .then(() => {


### PR DESCRIPTION
Fixes #46
- Frontend only count running machine on the dashboard
- `createMachine` returns almost instantly so the `MachineServer` could set the machine as booting
- `createMachine` then poll periodically to retrieve booting machine states (implement a refresh function in `Machine` and `MachineServer` as well as in every driver)
- Every driver implements a `getPassword` function to retrieve the password
- The broker do not to assign booting machines to a user

Work inspired from https://github.com/Nanocloud/nanocloud/pull/225
