### PR TITLE
Fix regular users are automatically assigned a machine on login

### DIFF
--- a/assets/app/protected/apps/index/template.hbs
+++ b/assets/app/protected/apps/index/template.hbs
@@ -49,6 +49,7 @@
 {{#floating-sidebar-component
   isVisible=showFileExplorer
 }}
+{{#if showFileExplorer}}
   {{#application-publisher
     isPublishing=isPublishing
     api="file"
@@ -57,4 +58,5 @@
     action="refreshModel"
   }}
   {{/application-publisher}}
+{{/if}}
 {{/floating-sidebar-component}}


### PR DESCRIPTION
Fixes https://github.com/Nanocloud/nanocloud/issues/228

Only display the application-publisher if the file explorer is actuually shown
