### PR TITLE
Add Qemu manager and driver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ docker-compose.yml
 docker-compose-dev.yml
 LICENSE
 README.md
+qemu

--- a/README.md
+++ b/README.md
@@ -53,15 +53,25 @@ AWS driver specific:
 - creditLimit (Defaults empty string) set a credit limit to users (aws only)
 
 Openstack driver specific:
- - openstackUsername username to connect to openstack
- - openstackPassword password to connect to openstack
- - openstackAuthUrl url of the openstack's API (example: https://identity.example.com:5000)
- - openstackRegion (Defaults to 'RegionOne') region name to use on openstack
- - openstackImage if of the image to boot Windows execution servers from
- - openstackFlavor (defaults to m1.medium) flavor for the virtual machine
- - openstackSecurityGroups (Defaults to ['default']) array of security groups to apply to the instance
- - openstackMachineUsername (Defaults to Administrator) windows account username
- - openstackMachinePassword (Defaults empty, password will generated) windows account password
+- openstackUsername username to connect to openstack
+- openstackPassword password to connect to openstack
+- openstackAuthUrl url of the openstack's API (example: https://identity.example.com:5000)
+- openstackRegion (Defaults to 'RegionOne') region name to use on openstack
+- openstackImage if of the image to boot Windows execution servers from
+- openstackFlavor (defaults to m1.medium) flavor for the virtual machine
+- openstackSecurityGroups (Defaults to ['default']) array of security groups to apply to the instance
+- openstackMachineUsername (Defaults to Administrator) windows account username
+- openstackMachinePassword (Defaults empty, password will generated) windows account password
+
+Qemu driver specific:
+- qemuServiceURL (Default to localhost) url of qemu manager service
+- qemuServicePort (Default to 3000) port of qemu manager service
+- qemuMemory (Default to 4096) memory to allocate to your VMs in MB
+- qemuCPU (Default to 2) number of vCPU to allocate to your VMs
+- qemuMachineUsername (Defaults to Administrator) windows account username
+- qemuMachinePassword (Defaults empty) windows account password
+
+Qemu use '10.0.2.2' to contact host, you should replace default 'localhost' by this ip to be able to use storage.
 
 Storage configuration:
 - storageAddress (mandatory, defaults to 'localhost') storage service's IP

--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -223,7 +223,7 @@ module.exports = {
                 machineId: machine.id,
                 machineType: machine.flavor,
                 machineDriver: machine.type,
-                port: 3389,
+                port: machine.rdpPort,
                 username: machine.username,
                 password: machine.password,
                 'remote-app': '',

--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -272,6 +272,7 @@ class AWSDriver extends Driver {
                       password: null,
                       domain: '',
                       plazaport: config.plazaPort,
+                      rdpPort: 3389
                     });
                     return resolve(machine);
                   });

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -142,7 +142,8 @@ class DummyDriver extends BaseDriver {
       ip        : _plazaAddress,
       username  : 'Administrator',
       plazaport : _plazaPort,
-      domain    : ''
+      domain    : '',
+      rdpPort   : 3389
     });
 
     this._machines[machine.id] = machine;

--- a/api/drivers/openstack/driver.js
+++ b/api/drivers/openstack/driver.js
@@ -174,7 +174,8 @@ class OpenstackDriver extends Driver {
                     username  : config.openstackMachineUsername,
                     password  : password,
                     domain    : '',
-                    plazaport : config.plazaPort
+                    plazaport : config.plazaPort,
+                    rdpPort   : 3389
                   });
 
                   return resolve(machine);

--- a/api/drivers/qemu/driver.js
+++ b/api/drivers/qemu/driver.js
@@ -1,0 +1,190 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global Machine, ConfigService*/
+
+const request = require('request-promise');
+const Driver = require('../driver');
+
+/**
+ * Driver for Qemu API
+ *
+ * @class QemuDriver
+ */
+class QemuDriver extends Driver {
+
+  /**
+   * Initializes the Qemu driver.
+   *
+   * @method initialize
+   * @return {Promise}
+   */
+  initialize() {
+    return ConfigService.get('qemuServiceURL', 'qemuServicePort')
+      .then((config) => {
+
+        let requestOptions = {
+          url: 'http://' + config.qemuServiceURL + ':' + config.qemuServicePort,
+          method: 'GET'
+        };
+
+        return request(requestOptions);
+      });
+  }
+
+  /**
+   * Return the name of the driver.
+   *
+   * @method name
+   * @return {String} The name of the driver
+   */
+  name() {
+    return 'qemu';
+  }
+
+  /**
+   * Create a new virtual machine. It uses the `ConfigService` variables:
+   *  - qemuMemory: Memory in MB
+   *  - qemuCPU: Number of vCPU
+   *  - qemuDrive: Hard drive file (qcow2)
+   *  - qemuMachineUsername: Windows account username
+   *  - qemuMachinePassword: Windows account password
+   *
+   * @method createMachine
+   * @param {Object} options The machine options. `options.name`: The name of
+   * the machine
+   * @return {Promise[Machine]} The created machine
+   */
+  createMachine(options) {
+    return ConfigService.get('qemuServiceURL', 'qemuServicePort',
+      'qemuMemory', 'qemuCPU', 'plazaPort',
+      'qemuMachineUsername', 'qemuMachinePassword')
+      .then((config) => {
+        let requestOptions = {
+          url: 'http://' + config.qemuServiceURL + ':' + config.qemuServicePort + '/machines',
+          json: true,
+          body: {
+            name: options.name,
+            cpu: config.qemuCPU,
+            memory: config.qemuMemory,
+          },
+          method: 'POST'
+        };
+
+        return request(requestOptions)
+          .then((res) => {
+            return new Machine._model({
+              id        : res.id,
+              name      : res.name,
+              type      : this.name(),
+              ip        : config.qemuServiceURL,
+              username  : config.qemuMachineUsername,
+              password  : config.qemuMachinePassword,
+              domain    : '',
+              plazaport : res.plazaPort,
+              rdpPort   : res.rdpPort,
+              status    : res.status
+            });
+          });
+      });
+  }
+
+  /**
+   * Destroy the specified machine.
+   *
+   * @method destroyMachine
+   * @return {Promise}
+   */
+  destroyMachine(machine) {
+    return ConfigService.get('qemuServiceURL', 'qemuServicePort')
+      .then((config) => {
+        let requestOptions = {
+          url: 'http://' + config.qemuServiceURL + ':' + config.qemuServicePort + '/machines/' + machine.id,
+          json: true,
+          method: 'DELETE'
+        };
+
+        return request(requestOptions)
+          .then((res) => {
+            return(res);
+          });
+      });
+  }
+
+  /**
+   * Retrieve the machine's password
+   *
+   * @method getPassword
+   * @param {machine} Machine model
+   * @return {Promise[String]}
+   */
+  getPassword() {
+    return ConfigService.get('qemuMachinePassword')
+      .then((config) => {
+        return (config.qemuMachinePassword);
+      });
+  }
+
+  /**
+   * Retrieve the server with the specified id.
+   *
+   * @method getServer
+   * @return {Promise[Object]}
+   */
+  getServer(id) {
+    // Not implemented yet
+    return id;
+  }
+
+  /*
+   * Create an image from a machine
+   * The image will be used as default image for future execution servers
+   *
+   * @method createImage
+   * @param {Object} Image object with `buildFrom` attribute set to the machine id to create image from
+   * @return {Promise[Image]} resolves to the new default image
+   */
+  createImage(imageToCreate) {
+    return imageToCreate;
+  }
+
+  /**
+   * Retrieve the machine's data
+   *
+   * @method refresh
+   * @param {machine} Machine model
+   * @return {Promise[Machine]}
+   */
+  refresh(machine) {
+    let requestOptions = {
+      url: 'http://' + machine.ip + ':' + machine.plazaport,
+      method: 'GET'
+    };
+    return request(requestOptions)
+      .then(() => {
+        machine.status = 'running';
+        return machine;
+      });
+  }
+}
+
+module.exports = QemuDriver;

--- a/api/migrations/022_add_rdp_port_column_in_machine.js
+++ b/api/migrations/022_add_rdp_port_column_in_machine.js
@@ -1,0 +1,37 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex) {
+  return knex.schema.table('machine', (table) => {
+    table.integer('rdpPort');
+  });
+}
+
+function down(knex) {
+  return knex.schema.table('machine', (table) => {
+    table.dropColumn('rdpPort');
+  });
+}
+
+module.exports = { up, down };

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -61,6 +61,9 @@ module.exports = {
     endDate: {
       type: 'datetime'
     },
+    rdpPort: {
+      type: 'integer'
+    },
     plazaport: {
       type: 'integer'
     },

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -28,6 +28,7 @@ const Promise = require('bluebird');
 const ManualDriver = require('../drivers/manual/driver');
 const AWSDriver = require('../drivers/aws/driver');
 const DummyDriver = require('../drivers/dummy/driver');
+const QemuDriver = require('../drivers/qemu/driver');
 const OpenstackDriver = require('../drivers/openstack/driver');
 const promisePoller = require('promise-poller').default;
 
@@ -44,6 +45,7 @@ const drivers = {
   manual    : ManualDriver,
   aws       : AWSDriver,
   dummy     : DummyDriver,
+  qemu      : QemuDriver,
   openstack : OpenstackDriver
 };
 

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -111,6 +111,13 @@ module.exports = {
     openstackFlavor: 'm1.medium',
     openstackSecurityGroups: ['default'],
     openstackMachineUsername: 'Administrator',
-    openstackMachinePassword: ''
+    openstackMachinePassword: '',
+
+    qemuServiceURL: 'localhost',
+    qemuServicePort: 3000,
+    qemuMemory: '4096',
+    qemuCPU: '2',
+    qemuMachineUsername: 'Administrator',
+    qemuMachinePassword: ''
   }
 };

--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -23,6 +23,16 @@ services:
       file: docker-compose.yml
       service: plaza
 
+  qemu-manager:
+    build: ./qemu
+    image: nanocloud/qemu-manager
+    volumes:
+      - ./qemu/image.qcow2:/data/image.qcow2
+    devices:
+      - /dev/kvm
+    network_mode: host
+    container_name: "qemumanager"
+
 networks:
   nanocloud:
     driver: bridge

--- a/docs/nanocloud-qemu.yml
+++ b/docs/nanocloud-qemu.yml
@@ -1,0 +1,78 @@
+---
+swagger: '2.0'
+info:
+  version: "2.0.0"
+  title: Nanocloud libvirt module API
+  description: |
+    **Complete Nanocloud libvirt module API documentation.**
+
+    You can try all HTTP operation described in this Swagger spec.
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /machines:
+    post:
+      summary:
+        Create a new machine
+      parameters:
+        - in: body
+          name: data
+          description: Machine description
+          required: true
+          schema:
+              $ref: "#/definitions/Machine"
+      responses:
+        201:
+          description: A VM is booting
+        400:
+          description: Machine description is missing or incomplete
+
+  /machines/{machine_uuid}:
+    delete:
+      summary:
+        Stop specified VM. This won't delete it
+      parameters:
+        - in: path
+          name: machine_uuid
+          description: Machine's UUID
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: VM has been stopped
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/MachineDeleted"
+        404:
+          description: No machine found with this UUID
+
+definitions:
+  Machine:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      status:
+        type: string
+      vncPort:
+        type: number
+      rdpPort:
+        type: number
+      plazaPort:
+        type: number
+  MachineDeleted:
+    type: object
+    properties:
+      id:
+        type: string
+      status:
+        type: string

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,4 +1,9 @@
 {
     "verbose": true,
-    "ignore": ["assets/*", "postgres/*", "guacamole-client/*", "proxy/*"]
+    "ignore": [
+      "assets/*",
+      "postgres/*",
+      "guacamole-client/*",
+      "proxy/*",
+      "qemu/*"]
 }

--- a/qemu/.dockerignore
+++ b/qemu/.dockerignore
@@ -1,0 +1,1 @@
+image.qcow2

--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:8.5
+MAINTAINER Romain Soufflet <romain.soufflet@nanocloud.com>
+
+RUN apt-get update -y && \
+    apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y git nodejs qemu-system-x86
+
+WORKDIR /opt
+
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN cp -a /tmp/node_modules /opt/
+
+COPY ./ /opt/
+
+EXPOSE 3000
+
+CMD ["node", "index.js"]

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -1,0 +1,15 @@
+# QEMU Manager
+
+Manages local machines using Qemu.
+
+# Installation
+
+A qcow2 image is expected to be located in `./qemu/image.qcow2`.
+This image must be a Windows Server 2012 with plaza installed an RDP
+enabled.
+
+You can download a qcow2 image with this link: https://s3-eu-west-1.amazonaws.com/nanocloud/windows-server-2012-r2.qcow2
+
+```
+docker-compose -f docker-compose-extra.yml up qemu-manager
+```

--- a/qemu/index.js
+++ b/qemu/index.js
@@ -1,0 +1,106 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const drive = '/data/image.qcow2';
+
+var express = require('express');
+var app = express();
+var bodyParser = require('body-parser');
+var multer = require('multer'); // v1.0.5
+var upload = multer(); // for parsing multipart/form-data
+var uuid = require('uuid');
+var exec = require('child_process').exec;
+
+
+function getPort() {
+  getPort.plaza =  ++getPort.plaza || 28000;
+  getPort.rdp =  ++getPort.rdp || 29000;
+  getPort.vnc =  ++getPort.vnc || 1;
+
+  return ({
+    plaza: getPort.plaza,
+    rdp: getPort.rdp,
+    vnc: getPort.vnc
+  });
+}
+
+app.use(function(req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+  next();
+});
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+
+app.post('/machines', upload.array(), function (req, res) {
+  var machineDescription = req.body;
+  var id = uuid.v4();
+  var name = machineDescription.name + '-qemu-' + id;
+  var port = getPort();
+  var cmd = `qemu-system-x86_64 \
+    -nodefaults \
+    -name "${name}" \
+    -m ${machineDescription.memory} \
+    -smp ${machineDescription.cpu} \
+    -machine accel=kvm \
+    -drive file=${drive},format=qcow2 \
+    -vnc :${port.vnc} \
+    -usb -device usb-tablet \
+    -net nic,vlan=0,model=virtio \
+    -net user,vlan=0,hostfwd=tcp::${port.plaza}-:9090,hostfwd=tcp::${port.rdp}-:3389 \
+    -vga qxl \
+  `;
+
+  exec(cmd, () => {});
+
+  return res.json({
+    id: id,
+    name: name,
+    plazaPort: port.plaza,
+    rdpPort: port.rdp,
+    vncPort: port.vnc,
+    status: 'booting'
+  });
+
+});
+
+app.delete('/machines/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', function (req, res) {
+
+  var machineId = req.path.substr(10);
+
+  exec('PID=$(ps aux | grep "' + machineId + ' " | grep qemu | awk \'{ print $2 }\' | tr "\\n" " ") ; kill ${PID}',
+    () => {});
+
+  return res.json({
+    id: machineId,
+    status: 'stopping'
+  });
+
+});
+
+app.get('/', function (req, res) {
+  return res.send('Qemu manager');
+});
+
+app.listen(3000, function () {
+  // Qemu Manager listen on port 3000
+});

--- a/qemu/package.json
+++ b/qemu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "qemuManager",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Manage Qemu",
+  "keywords": [],
+  "dependencies": {
+    "bluebird": "^3.4.6",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "multer": "^1.2.0",
+    "uuid": "^2.0.2"
+  },
+  "scripts": {
+    "test": "make tests",
+    "debug": "node debug app.js",
+    "start": "node app.js"
+  },
+  "main": "app.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Nanocloud/nanocloud"
+  },
+  "author": "Romain Soufflet <romain.soufflet@nanocloud.com>",
+  "license": "AGPL-3.0"
+}


### PR DESCRIPTION
Add an optional docker container to provide a small API managing Qemu to work with Nanocloud.
- _qemu_ directory will contains qemu manager
- A documentation files has been added to _docs_
- Users will have to provide their own .qcow2 file

Co-authored-by: Romain Soufflet romain.soufflet@nanocloud.com

Replace PR #238 
Fixes #186 
