### PR TITLE
Allow administrators to customize email template

### DIFF
--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -72,15 +72,14 @@ module.exports = {
       .then((configuration) => {
         var host = configuration.host;
         var to =  user.email;
-        var subject = 'Nanocloud - Verify your email address';
 
-        return TemplateService.render('activation-email', {
+        return TemplateService.render('activation', {
           firstName: user['first-name'],
           lastName: user['last-name'],
           activationLink: `http://${host}/#/activate/${user.token}`
         })
-          .then((message) => {
-            return EmailService.sendMail(to, subject, message)
+          .then((template) => {
+            return EmailService.sendMail(to, template.subject, template.content)
               .then(() => {
                 let userToAdd = JsonApiService.deserialize(user);
                 let teamId = _.get(req.body, 'data.relationships.team.data.id');

--- a/api/controllers/Reset-passwordController.js
+++ b/api/controllers/Reset-passwordController.js
@@ -59,17 +59,16 @@ module.exports = {
     // send him reset password link
       .then((configuration) => {
         let host = configuration.host;
-        let subject = 'Nanocloud - Reset your password';
         let to = user.email;
 
-        return TemplateService.render('reset-password-email', {
+        return TemplateService.render('reset', {
           firstName: user.firstName,
           lastName: user.lastName,
           resetLink: `http://${host}/#/reset-password/${token}`
         })
-          .then((message) => {
+          .then((template) => {
             // mail sent here
-            return EmailService.sendMail(to, subject, message);
+            return EmailService.sendMail(to, template.subject, template.content);
           });
       })
       .then(() => {

--- a/api/controllers/TemplateController.js
+++ b/api/controllers/TemplateController.js
@@ -21,34 +21,13 @@
  *
  */
 
-/* globals Template */
-
-const Handlebars = require('handlebars');
-
 /**
- * render
+ * TemplateController
  *
- * Find the template associated to emailKey and return email subject and
- * content with appropriate data
- *
- * @param {String} emailKey associate to the template
- * @param {Object} All data availble to inject in email
- * @return {Object} Object with subject and content with appropriate data
+ * @description :: Server-side logic for managing email template
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
-function render(emailKey, data) {
 
-  return Template.findOne({
-    key: emailKey
-  })
-    .then((template) => {
-      let tmpl = Handlebars.compile(template.content.toString());
-      let content = tmpl(data);
+module.exports = {
 
-      return ({
-        content: content,
-        subject: template.subject
-      });
-    });
-}
-
-module.exports = { render };
+};

--- a/api/migrations/020_create_template_table.js
+++ b/api/migrations/020_create_template_table.js
@@ -1,0 +1,41 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex) {
+  return knex.schema.createTable('template', (table) => {
+    table.string('id').primary();
+    table.string('key');
+    table.string('subject');
+    table.string('content');
+
+    table.dateTime('createdAt');
+    table.dateTime('updatedAt');
+  });
+}
+
+function down(knex) {
+  knex.schema.dropTable('template');
+}
+
+module.exports = { up, down };

--- a/api/models/Template.js
+++ b/api/models/Template.js
@@ -18,37 +18,37 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-/* globals Template */
-
-const Handlebars = require('handlebars');
+const uuid = require('node-uuid');
 
 /**
- * render
+ * Template.js
  *
- * Find the template associated to emailKey and return email subject and
- * content with appropriate data
- *
- * @param {String} emailKey associate to the template
- * @param {Object} All data availble to inject in email
- * @return {Object} Object with subject and content with appropriate data
+ * @description :: Template's model
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
  */
-function render(emailKey, data) {
+module.exports = {
 
-  return Template.findOne({
-    key: emailKey
-  })
-    .then((template) => {
-      let tmpl = Handlebars.compile(template.content.toString());
-      let content = tmpl(data);
+  autoPK: false,
 
-      return ({
-        content: content,
-        subject: template.subject
-      });
-    });
-}
-
-module.exports = { render };
+  attributes: {
+    id: {
+      type: 'string',
+      primaryKey: true,
+      unique: true,
+      index: true,
+      uuidv4: true,
+      defaultsTo: function (){ return uuid.v4(); }
+    },
+    key: {
+      type: 'string'
+    },
+    content: {
+      type: 'string'
+    },
+    subject: {
+      type: 'string'
+    }
+  }
+};

--- a/api/seeds/template.js
+++ b/api/seeds/template.js
@@ -1,0 +1,71 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+const path = require('path');
+
+function seed(knex) {
+
+  let viewsDirectory = './api/views';
+  let activationEmail = null;
+  let resetPasswordEmail = null;
+
+  return fs.readFileAsync(path.join(viewsDirectory, `activation-email.hbs`))
+    .then((content) => {
+      activationEmail = content;
+      return fs.readFileAsync(path.join(viewsDirectory, `reset-password-email.hbs`))
+        .then((content) => {
+          resetPasswordEmail = content;
+        });
+    })
+    .then(() => {
+      return knex.raw(`
+        INSERT INTO "template" (
+          "id",
+          "key",
+          "subject",
+          "content",
+          "createdAt",
+          "updatedAt"
+        ) VALUES (
+          :id1, :key1, :subject1, :content1, NOW(), NOW()
+        ), (
+          :id2, :key2, :subject2, :content2, NOW(), NOW()
+        )
+          ON CONFLICT DO NOTHING
+        `, {
+          id1: '1f300d1b-6aff-4029-b9b4-8c5d71074173',
+          key1: 'activation',
+          subject1: 'Nanocloud - Verify your email address',
+          content1: activationEmail,
+          id2: '03ef4f6a-9832-4964-813a-a84922a87918',
+          key2: 'reset',
+          subject2: 'Nanocloud - Reset your password',
+          content2: resetPasswordEmail,
+        });
+    });
+}
+
+module.exports = { seed };

--- a/assets/app/protected/configs/email-configuration/controller.js
+++ b/assets/app/protected/configs/email-configuration/controller.js
@@ -25,4 +25,12 @@
 import Ember from 'ember';
 export default Ember.Controller.extend({
   configController: Ember.inject.controller('protected.configs'),
+
+  text: "Hello world",
+
+  actions: {
+    textChanged(newValue) {
+      this.set('text', newValue);
+    }
+  }
 });

--- a/assets/app/protected/configs/email-configuration/controller.js
+++ b/assets/app/protected/configs/email-configuration/controller.js
@@ -25,12 +25,4 @@
 import Ember from 'ember';
 export default Ember.Controller.extend({
   configController: Ember.inject.controller('protected.configs'),
-
-  text: "Hello world",
-
-  actions: {
-    textChanged(newValue) {
-      this.set('text', newValue);
-    }
-  }
 });

--- a/assets/app/protected/configs/email-configuration/forget-password/controller.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/controller.js
@@ -1,11 +1,26 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  text: "Hello world",
 
   actions: {
     textChanged(newValue) {
-      this.set('text', newValue);
+      this.set('template', newValue);
+    },
+
+    saveChanges() {
+      let data = this.get('template');
+      data = data.split(/\[/).join('{').split(/\]/).join('}');
+
+      let model = this.get('model');
+      model.set('content', data);
+
+      model.save()
+        .then(() => {
+          this.toast.success('Forget password email template has been updated successfully.');
+        })
+        .catch(() => {
+          this.toast.success('Forget password email template could not be updated.');
+        });
     }
   }
 });

--- a/assets/app/protected/configs/email-configuration/forget-password/controller.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/controller.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  text: "Hello world",
+
+  actions: {
+    textChanged(newValue) {
+      this.set('text', newValue);
+    }
+  }
+});

--- a/assets/app/protected/configs/email-configuration/forget-password/controller.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/controller.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Controller.extend({

--- a/assets/app/protected/configs/email-configuration/forget-password/route.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/assets/app/protected/configs/email-configuration/forget-password/route.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/route.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Route.extend({

--- a/assets/app/protected/configs/email-configuration/forget-password/route.js
+++ b/assets/app/protected/configs/email-configuration/forget-password/route.js
@@ -1,4 +1,16 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+
+  setupController(controller, model) {
+    let newModel = model.filterBy('key', 'reset').objectAt(0);
+    let newContent = newModel.get('content').split(/{/).join('[').split(/}/).join(']');
+    newModel.set('content', newContent);
+    controller.set('template', newContent);
+    controller.set('model', newModel);
+  },
+
+  model() {
+    return this.store.query('template', {});
+  }
 });

--- a/assets/app/protected/configs/email-configuration/forget-password/template.hbs
+++ b/assets/app/protected/configs/email-configuration/forget-password/template.hbs
@@ -1,0 +1,4 @@
+<div class='m-t-1 m-b-1'>
+  {{ember-ckeditor value=text on-change="textChanged"}}
+</div>
+<button class="btn btn-primary">Submit</button>

--- a/assets/app/protected/configs/email-configuration/forget-password/template.hbs
+++ b/assets/app/protected/configs/email-configuration/forget-password/template.hbs
@@ -1,4 +1,4 @@
 <div class='m-t-1 m-b-1'>
-  {{ember-ckeditor value=text on-change="textChanged"}}
+  {{ember-ckeditor value=template on-change="textChanged"}}
 </div>
-<button class="btn btn-primary">Submit</button>
+<button {{ action 'saveChanges' }} class="btn btn-primary">Update</button>

--- a/assets/app/protected/configs/email-configuration/index/controller.js
+++ b/assets/app/protected/configs/email-configuration/index/controller.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  configController: Ember.inject.controller('protected.configs'),
+});

--- a/assets/app/protected/configs/email-configuration/index/controller.js
+++ b/assets/app/protected/configs/email-configuration/index/controller.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Controller.extend({

--- a/assets/app/protected/configs/email-configuration/index/route.js
+++ b/assets/app/protected/configs/email-configuration/index/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/assets/app/protected/configs/email-configuration/index/route.js
+++ b/assets/app/protected/configs/email-configuration/index/route.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Route.extend({

--- a/assets/app/protected/configs/email-configuration/index/template.hbs
+++ b/assets/app/protected/configs/email-configuration/index/template.hbs
@@ -1,0 +1,35 @@
+<h5 class="m-t-2 m-b-2">Email Configuration</h5>
+<div class="m-t-1 form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Server Host:</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm placeholder=smtpServerHost value=configController.smtpServerHost type="text"}}</div>
+</div>
+
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Server Port:</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm value=configController.smtpServerPort type="number" min="1"}}</div>
+</div>
+
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Login:</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm value=configController.smtpLogin type="text"}}</div>
+</div>
+
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Password:</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm value=configController.smtpPassword placeholder="******" type="password" pattern=".{6,}"}}</div>
+</div>
+
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Send From:</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm value=configController.smtpSendFrom type="email"}}</div>
+</div>

--- a/assets/app/protected/configs/email-configuration/sign-up/controller.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/controller.js
@@ -1,11 +1,26 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  text: "Hello world",
 
   actions: {
     textChanged(newValue) {
-      this.set('text', newValue);
+      this.set('template', newValue);
+    },
+
+    saveChanges() {
+      let data = this.get('template');
+      data = data.split(/\[/).join('{').split(/\]/).join('}');
+
+      let model = this.get('model');
+      model.set('content', data);
+
+      model.save()
+        .then(() => {
+          this.toast.success('Activation email template has been updated successfully.');
+        })
+        .catch(() => {
+          this.toast.success('Activation email template could not be updated.');
+        });
     }
   }
 });

--- a/assets/app/protected/configs/email-configuration/sign-up/controller.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/controller.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  text: "Hello world",
+
+  actions: {
+    textChanged(newValue) {
+      this.set('text', newValue);
+    }
+  }
+});

--- a/assets/app/protected/configs/email-configuration/sign-up/controller.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/controller.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Controller.extend({

--- a/assets/app/protected/configs/email-configuration/sign-up/route.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/assets/app/protected/configs/email-configuration/sign-up/route.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/route.js
@@ -1,4 +1,16 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+
+  setupController(controller, model) {
+    let newModel = model.filterBy('key', 'activation').objectAt(0);
+    let newContent = newModel.get('content').split(/{/).join('[').split(/}/).join(']');
+    newModel.set('content', newContent);
+    controller.set('template', newContent);
+    controller.set('model', newModel);
+  },
+
+  model() {
+    return this.store.query('template', {});
+  }
 });

--- a/assets/app/protected/configs/email-configuration/sign-up/route.js
+++ b/assets/app/protected/configs/email-configuration/sign-up/route.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import Ember from 'ember';
 
 export default Ember.Route.extend({

--- a/assets/app/protected/configs/email-configuration/sign-up/template.hbs
+++ b/assets/app/protected/configs/email-configuration/sign-up/template.hbs
@@ -1,0 +1,4 @@
+<div class='m-t-1 m-b-1'>
+  {{ember-ckeditor value=text on-change="textChanged"}}
+</div>
+<button class="btn btn-primary">Submit</button>

--- a/assets/app/protected/configs/email-configuration/sign-up/template.hbs
+++ b/assets/app/protected/configs/email-configuration/sign-up/template.hbs
@@ -1,4 +1,4 @@
 <div class='m-t-1 m-b-1'>
-  {{ember-ckeditor value=text on-change="textChanged"}}
+  {{ember-ckeditor value=template on-change="textChanged"}}
 </div>
-<button class="btn btn-primary">Submit</button>
+<button {{ action 'saveChanges' }} class="btn btn-primary">Update</button>

--- a/assets/app/protected/configs/email-configuration/template.hbs
+++ b/assets/app/protected/configs/email-configuration/template.hbs
@@ -33,3 +33,5 @@
   </div>
   <div class="col-sm-3">{{input-confirm value=configController.smtpSendFrom type="email"}}</div>
 </div>
+
+{{ember-ckeditor value=text on-change="textChanged"}}

--- a/assets/app/protected/configs/email-configuration/template.hbs
+++ b/assets/app/protected/configs/email-configuration/template.hbs
@@ -1,37 +1,14 @@
-<h5 class="m-t-1 m-b-2">Email Configuration</h5>
-<div class="m-t-1 form-group row">
-  <div class="col-sm-2">
-    <p class="confirm-input-item color-primary in-bl fl">Server Host:</p>
-  </div>
-  <div class="col-sm-3">{{input-confirm placeholder=smtpServerHost value=configController.smtpServerHost type="text"}}</div>
+<div class="configuration m-t-1">
+  <ul class="nav nav-pills">
+    <li class="nav-item">
+      {{#link-to 'protected.configs.email-configuration.index' class='nav-link' }}Settings{{/link-to}}
+    </li>
+    <li class="nav-item">
+      {{#link-to 'protected.configs.email-configuration.sign-up' class='nav-link'}}Signup template{{/link-to}}
+    </li>
+    <li class="nav-item">
+      {{#link-to 'protected.configs.email-configuration.forget-password' class='nav-link'}}Forget password template{{/link-to}}
+    </li>
+  </ul>
+  {{outlet}}
 </div>
-
-<div class="form-group row">
-  <div class="col-sm-2">
-    <p class="confirm-input-item color-primary in-bl fl">Server Port:</p>
-  </div>
-  <div class="col-sm-3">{{input-confirm value=configController.smtpServerPort type="number" min="1"}}</div>
-</div>
-
-<div class="form-group row">
-  <div class="col-sm-2">
-    <p class="confirm-input-item color-primary in-bl fl">Login:</p>
-  </div>
-  <div class="col-sm-3">{{input-confirm value=configController.smtpLogin type="text"}}</div>
-</div>
-
-<div class="form-group row">
-  <div class="col-sm-2">
-    <p class="confirm-input-item color-primary in-bl fl">Password:</p>
-  </div>
-  <div class="col-sm-3">{{input-confirm value=configController.smtpPassword placeholder="******" type="password" pattern=".{6,}"}}</div>
-</div>
-
-<div class="form-group row">
-  <div class="col-sm-2">
-    <p class="confirm-input-item color-primary in-bl fl">Send From:</p>
-  </div>
-  <div class="col-sm-3">{{input-confirm value=configController.smtpSendFrom type="email"}}</div>
-</div>
-
-{{ember-ckeditor value=text on-change="textChanged"}}

--- a/assets/app/protected/configs/template.hbs
+++ b/assets/app/protected/configs/template.hbs
@@ -1,4 +1,4 @@
-<div class="configuration section p-a-2">
+<div class="configuration p-a-2">
   <ul class="nav nav-pills">
     <li class="nav-item">
       {{#link-to 'protected.configs.index' class='nav-link' }}Session{{/link-to}}

--- a/assets/app/router.js
+++ b/assets/app/router.js
@@ -62,7 +62,10 @@ Router.map(function() {
     this.route('dashboard');
     this.route('configs', function() {
       this.route('user-right');
-      this.route('email-configuration');
+      this.route('email-configuration', function() {
+        this.route('sign-up');
+        this.route('forget-password');
+      });
       this.route('other-setting');
       this.route('look-and-feel');
     });

--- a/assets/app/template/model.js
+++ b/assets/app/template/model.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  key: DS.attr('string'),
+  content: DS.attr('string'),
+  subject: DS.attr('string'),
+  createdAt: DS.attr('date'),
+  updatedAt: DS.attr('date'),
+});

--- a/assets/app/template/model.js
+++ b/assets/app/template/model.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -9,6 +9,7 @@
     "toastr": "^2.1.2",
     "font-awesome": "~4.5.0",
     "tooltipster": "^3.3.0",
-    "humanize-duration": "^3.9.0"
+    "humanize-duration": "^3.9.0",
+    "ckeditor": "^4.5.11"
   }
 }

--- a/assets/node_modules/ember-ckeditor/addon/components/ember-ckeditor.js
+++ b/assets/node_modules/ember-ckeditor/addon/components/ember-ckeditor.js
@@ -1,0 +1,36 @@
+/* globals CKEDITOR */
+import Ember from 'ember';
+import layout from '../templates/components/ember-ckeditor';
+
+export default Ember.Component.extend({
+  layout: layout,
+
+  _editor: null,
+  'on-change': null,
+
+  didInsertElement() {
+    let textarea = this.element.querySelector('.editor');
+    let editor = this._editor = CKEDITOR.replace(textarea,  {
+      extraPlugins: 'placeholder',
+      toolbar: [
+        [ 'Source', '-', 'Save', 'NewPage', '-', 'Undo', 'Redo' ],
+        [ 'Find', 'Replace', '-', 'SelectAll', 'RemoveFormat' ],
+        [ 'Link', 'Unlink', 'Image' ],
+        '/',
+        [ 'FontSize', 'Bold', 'Italic', 'Underline' ],
+        [ 'NumberedList', 'BulletedList', '-', 'Blockquote' ],
+        [ 'TextColor', '-', 'Smiley', 'SpecialChar', '-', 'Maximize' ],
+        ['CreatePlaceholder']
+      ],
+    });
+
+    editor.on('change', (e) => {
+      this.sendAction('on-change', e.editor.getData());
+    });
+  },
+
+  willDestroyElement() {
+    this._editor.destroy();
+    this._editor = null;
+  }
+});

--- a/assets/package.json
+++ b/assets/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
+    "ember-ckeditor": "https://github.com/ebryn/ember-ckeditor.git",
     "ember-cli": "2.4.3",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",

--- a/assets/package.json
+++ b/assets/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
-    "ember-ckeditor": "https://github.com/ebryn/ember-ckeditor.git",
+    "ember-ckeditor": "0.0.1",
     "ember-cli": "2.4.3",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",

--- a/assets/tests/unit/protected/configs/email-configuration/forget-password/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/forget-password/controller-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:protected/configs/email-configuration/forget-password', 'Unit | Controller | protected/configs/email configuration/forget password', {

--- a/assets/tests/unit/protected/configs/email-configuration/forget-password/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/forget-password/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:protected/configs/email-configuration/forget-password', 'Unit | Controller | protected/configs/email configuration/forget password', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/forget-password/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/forget-password/route-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:protected/configs/email-configuration/forget-password', 'Unit | Route | protected/configs/email configuration/forget password', {

--- a/assets/tests/unit/protected/configs/email-configuration/forget-password/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/forget-password/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected/configs/email-configuration/forget-password', 'Unit | Route | protected/configs/email configuration/forget password', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/index/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/index/controller-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:protected/configs/email-configuration/index', 'Unit | Controller | protected/configs/email configuration/index', {

--- a/assets/tests/unit/protected/configs/email-configuration/index/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/index/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:protected/configs/email-configuration/index', 'Unit | Controller | protected/configs/email configuration/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/index/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/index/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected/configs/email-configuration/index', 'Unit | Route | protected/configs/email configuration/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/index/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/index/route-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:protected/configs/email-configuration/index', 'Unit | Route | protected/configs/email configuration/index', {

--- a/assets/tests/unit/protected/configs/email-configuration/sign-up/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/sign-up/controller-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:protected/configs/email-configuration/sign-up', 'Unit | Controller | protected/configs/email configuration/sign up', {

--- a/assets/tests/unit/protected/configs/email-configuration/sign-up/controller-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/sign-up/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:protected/configs/email-configuration/sign-up', 'Unit | Controller | protected/configs/email configuration/sign up', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/sign-up/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/sign-up/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected/configs/email-configuration/sign-up', 'Unit | Route | protected/configs/email configuration/sign up', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/assets/tests/unit/protected/configs/email-configuration/sign-up/route-test.js
+++ b/assets/tests/unit/protected/configs/email-configuration/sign-up/route-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:protected/configs/email-configuration/sign-up', 'Unit | Route | protected/configs/email configuration/sign up', {

--- a/assets/tests/unit/template/model-test.js
+++ b/assets/tests/unit/template/model-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('template', 'Unit | Model | template', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/assets/tests/unit/template/model-test.js
+++ b/assets/tests/unit/template/model-test.js
@@ -1,3 +1,27 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('template', 'Unit | Model | template', {

--- a/config/policies.js
+++ b/config/policies.js
@@ -133,5 +133,13 @@ module.exports.policies = {
     '*': false,
     find: 'isAdmin',
     findOne: 'isAdmin'
+  },
+
+  TemplateController: {
+    create: false,
+    update: 'isAdmin',
+    find: 'isAdmin',
+    findOne: 'isAdmin',
+    destroy: false
   }
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -95,6 +95,11 @@ module.exports.routes = {
     action: 'update'
   },
 
+  'PATCH /api/templates/:id': {
+    controller: 'Template',
+    action: 'update'
+  },
+
   'PATCH /api/:model/:id': {
     controller: 'Nanocloud',
     action: 'update'

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -1561,6 +1561,99 @@ paths:
         403:
           description: Only admin can list broker logs
 
+  /templates:
+    get:
+      tags:
+        - templates
+      summary:
+        Get a detailed list of templates
+      responses:
+        200:
+          description: Get all templates
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: "#/definitions/Templates"
+        403:
+          description: You are not an admin
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  $ref: "#/definitions/Errors"
+
+  /templates/{template_id}:
+    get:
+      tags:
+        - templates
+      summary:
+        Get details of a specific template
+      parameters:
+        - in: path
+          name: template_id
+          description: Id of the template to fetch
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: Get template details
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/definitions/Templates"
+        403:
+          description: You are not an admin
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  $ref: "#/definitions/Errors"
+
+    patch:
+      tags:
+        - templates
+      summary:
+        Update a specific template
+      parameters:
+        - in: path
+          name: template_id
+          description: Id of the template to update
+          required: true
+          type: string
+          format: uuid
+        - in: body
+          name: data
+          description: Template description
+          required: true
+          schema:
+            $ref: "#/definitions/TemplatesAttibutes"
+      responses:
+        200:
+          description: The template details updated
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: "#/definitions/Templates"
+        403:
+          description: You are not an admin
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  $ref: "#/definitions/Errors"
+
 definitions:
   Configuration:
     type: object
@@ -2157,6 +2250,7 @@ definitions:
         type: string
       status:
         type: number
+
   BrokerLog:
     type: object
     properties:
@@ -2172,3 +2266,43 @@ definitions:
         type: string
       pool-size:
         type: string
+
+  Templates:
+    type: object
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+        format: uuid
+      attributes:
+        type: object
+        properties:
+          key:
+            type: string
+          content:
+            type: string
+          subject:
+            type: string
+          created-at:
+            type: string
+            format: date-Time
+          updated-at:
+            type: string
+            format: date-Time
+
+  TemplatesAttibutes:
+    type: object
+    properties:
+      key:
+        type: string
+      content:
+        type: string
+      subject:
+        type: string
+      created-at:
+        type: string
+        format: date-Time
+      updated-at:
+        type: string
+        format: date-Time

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -39,6 +39,7 @@ const testMachine = require('./machine.test');
 const testImage = require('./image.test');
 const testHistories = require('./histories.test');
 const testTeam = require('./team.test');
+const testTemplate = require('./template.test');
 
 var request = require('supertest');
 
@@ -66,4 +67,5 @@ testMachine();
 testImage();
 testSession();
 testTeam();
+testTemplate();
 testSecurity();

--- a/tests/api/security.test.js
+++ b/tests/api/security.test.js
@@ -24,7 +24,7 @@
 
 /* globals sails, User, AccessToken, MachineService, Group */
 /* globals ConfigService, StorageService, Machine, Team, BrokerLog */
-/* globals PendingUser */
+/* globals PendingUser, Template  */
 
 const nano = require('./lib/nanotest');
 
@@ -2978,6 +2978,221 @@ module.exports = function() {
         it('Unauthenticate users token should be unauthorized', function(done) {
           nano.request(sails.hooks.http.app)
             .delete('/api/teams/' + team1.id)
+            .expect(403)
+            .end(done);
+        });
+      });
+    });
+
+    describe('Templates', function() {
+
+      let templateId = null;
+
+      before('Create a test template', function(done) {
+        Template.create({
+          key: 'test',
+          subject: 'test',
+          content: 'test'
+        })
+          .then((template) => {
+            templateId = template.id;
+            done();
+          });
+      });
+
+      after('Delete the test template', function(done) {
+        Template.destroy({
+          id: templateId
+        })
+          .then(() => {
+            done();
+          });
+      });
+
+      describe('Create a template - not available', function() {
+
+        it('Admins should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .post('/api/templates')
+            .set(nano.adminLogin())
+            .send({
+              data: {
+                attributes: {
+                  key: 'test',
+                  subject: 'test',
+                  content: 'test'
+                },
+                type: 'templates'
+              }
+            })
+            .expect(403)
+            .end(done);
+        });
+
+        it('Regular users should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .post('/api/templates')
+            .set('Authorization', 'Bearer ' + token)
+            .set(nano.adminLogin())
+            .send({
+              data: {
+                attributes: {
+                  key: 'test',
+                  subject: 'test',
+                  content: 'test'
+                },
+                type: 'templates'
+              }
+            })
+            .expect(403)
+            .end(done);
+        });
+
+        it('Request without authorization should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .post('/api/templates')
+            .set(nano.adminLogin())
+            .send({
+              data: {
+                attributes: {
+                  key: 'test',
+                  subject: 'test',
+                  content: 'test'
+                },
+                type: 'templates'
+              }
+            })
+            .expect(403)
+            .end(done);
+        });
+      });
+
+      describe('Get templates - only admins', function() {
+
+        it('Admins should be authorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates')
+            .set(nano.adminLogin())
+            .expect(200)
+            .end(done);
+        });
+
+        it('Regular users should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates')
+            .set('Authorization', 'Bearer ' + token)
+            .expect(403)
+            .end(done);
+        });
+
+        it('Request without authorization should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates')
+            .expect(401)
+            .end(done);
+        });
+      });
+
+      describe('Get one template - only admins', function() {
+
+        it('Admins should be authorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates/' + templateId)
+            .set(nano.adminLogin())
+            .expect(200)
+            .end(done);
+        });
+
+        it('Regular users should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates/' + templateId)
+            .set('Authorization', 'Bearer ' + token)
+            .expect(403)
+            .end(done);
+        });
+
+        it('Request without authorization should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates/' + templateId)
+            .expect(401)
+            .end(done);
+        });
+      });
+
+      describe('Update templates - only admins', function() {
+
+        it('Admins should be authorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .patch('/api/templates/' + templateId)
+            .set(nano.adminLogin())
+            .send({
+              data: {
+                attributes: {
+                  subject: 'New subject'
+                },
+                id: templateId,
+                type: 'templates'
+              }
+            })
+            .expect(200)
+            .end(done);
+        });
+
+        it('Regular users should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .patch('/api/templates/' + templateId)
+            .set('Authorization', 'Bearer ' + token)
+            .send({
+              data: {
+                attributes: {
+                  subject: 'New subject'
+                },
+                id: templateId,
+                type: 'templates'
+              }
+            })
+            .expect(403)
+            .end(done);
+        });
+
+        it('Request without authorization should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .patch('/api/templates/' + templateId)
+            .send({
+              data: {
+                attributes: {
+                  subject: 'New subject'
+                },
+                id: templateId,
+                type: 'templates'
+              }
+            })
+            .expect(401)
+            .end(done);
+        });
+      });
+
+      describe('Delete templates - only admins', function() {
+
+        it('Admins should be authorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .delete('/api/templates/' + templateId)
+            .set(nano.adminLogin())
+            .expect(403)
+            .end(done);
+        });
+
+        it('Regular users should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .delete('/api/templates/' + templateId)
+            .set('Authorization', 'Bearer ' + token)
+            .expect(403)
+            .end(done);
+        });
+
+        it('Request without authorization should be unauthorized', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .delete('/api/templates/' + templateId)
             .expect(403)
             .end(done);
         });

--- a/tests/api/template.test.js
+++ b/tests/api/template.test.js
@@ -1,0 +1,115 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* globals sails, Template */
+
+const nano = require('./lib/nanotest');
+const expect = require('chai').expect;
+
+module.exports = function() {
+
+  describe('Template', function() {
+
+    let templateId = null;
+
+    before(function(done) {
+      Template.create({
+        key: 'key',
+        subject: 'Subject',
+        content: 'Content'
+      })
+        .then((template) => {
+          templateId = template.id;
+          return Template.create({
+            key: 'test',
+            subject: 'test',
+            content: 'test'
+          });
+        })
+        .then(() => {
+          done();
+        });
+    });
+
+    after(function(done) {
+      Template.destroy({
+        id: templateId
+      })
+        .then(() => {
+          done();
+        });
+    });
+
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        key: {type: 'string'},
+        subject: {type: 'string'},
+        content: {type: 'string'},
+        'created-at': {type: 'string'},
+        'updated-at': {type: 'string'},
+      },
+      required: ['key', 'subject', 'content', 'created-at', 'updated-at'],
+      additionalProperties: false
+    };
+
+    describe('Update templates', function() {
+
+      it('Should correctly update template', function(done) {
+        return nano.request(sails.hooks.http.app)
+          .patch('/api/templates/' + templateId)
+          .set(nano.adminLogin())
+          .send({
+            data: {
+              attributes: {
+                key: 'newKey',
+                subject: 'New subject',
+                content: 'New content'
+              },
+              id: templateId,
+              type: 'templates'
+            }
+          })
+          .expect(200)
+          .expect((res) => {
+            expect(res.body.data.attributes.key).to.equal('newKey');
+            expect(res.body.data.attributes.subject).to.equal('New subject');
+            expect(res.body.data.attributes.content).to.equal('New content');
+          })
+          .end(done);
+      });
+
+      describe('Get templates', function() {
+        it('Should return a list of templates', function(done) {
+          return nano.request(sails.hooks.http.app)
+            .get('/api/templates')
+            .set(nano.adminLogin())
+            .expect(200)
+            .expect(nano.jsonApiSchema(expectedSchema))
+            .end(done);
+        });
+      });
+    });
+  });
+};

--- a/tests/unit/services/TemplateService.test.js
+++ b/tests/unit/services/TemplateService.test.js
@@ -1,0 +1,60 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/* globals TemplateService, Template*/
+
+const expect = require('chai').expect;
+
+describe('Template Service', function() {
+  before(function(done) {
+    Template.create({
+      key: 'test',
+      subject: 'test',
+      content: 'This is a {{test}}'
+    })
+      .then(() => {
+        done();
+      });
+  });
+
+  after(function(done) {
+    Template.destroy({
+      key: 'test'
+    })
+      .then(() => {
+        done();
+      });
+  });
+
+  describe('Check email template render', function () {
+    it('Should return email subject and email content with appropriate data', function(done) {
+      TemplateService.render('test', {test: 'word'})
+        .then((template) => {
+          expect(template.subject).to.equal('test');
+          expect(template.content).to.equal('This is a word');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
2 new tabs has been added under email-configuration page that allows admin to customize email template.

Closes #190 
