### PR TITLE
Allow user to self register with an existing email adress after 7 days.

### DIFF
--- a/api/controllers/PendingUserController.js
+++ b/api/controllers/PendingUserController.js
@@ -63,8 +63,19 @@ module.exports = {
         return Promise.reject(new Error('User already exists'));
       })
       .then((pendingUserResponse) => {
+        let host = ConfigService.get('host');
         if (!pendingUserResponse) {
-          return ConfigService.get('host');
+          return host;
+        }
+
+        let date = moment().unix();
+        let expirationDate = moment(pendingUserResponse.createdAt).add(7, 'days').unix();
+        if (expirationDate <= date) {
+          // Delete expirated pending user
+          return PendingUser.destroy({ email: user.email })
+            .then(() => {
+              return host;
+            });
         }
 
         return Promise.reject(new Error('User already exists'));


### PR DESCRIPTION
This PR fixes #43.
If a pending user is not activated after 7 days, it is possible to self register with the same email address. Expired account is deleted on the fly.
