### PR TITLE
Regular user now have a correct message if their expiration date is not set.

### DIFF
--- a/assets/app/protected/users/user/template.hbs
+++ b/assets/app/protected/users/user/template.hbs
@@ -106,7 +106,11 @@
                 {{/if}}
               {{/edit-text}}
             {{else}}
-              {{moment-calendar model.expirationDateInMs}}
+              {{#if model.expirationDate}}
+                {{moment-calendar model.expirationDateInMs}}
+              {{else}}
+                No expiration date set
+              {{/if}}
             {{/if}}
           </td>
 		</tr>


### PR DESCRIPTION
Fixes #263 

Replace "01/01/1970" by "No expiration date set"
