### PR TITLE
Regular user can use storage correctly in VDI with an image created by the admin

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -140,8 +140,40 @@ module.exports = {
                   })
                     .catch(() => {
                       // User storage is probably already mounted
+                      // When an image is published, sometimes storage does not work again
+                      // Let's delete the currupted storage and recreate it
                       // Let's ignore the error silently
-                      return Promise.resolve();
+
+                      return PlazaService.exec(machine.ip, machine.plazaport, {
+                        command: [
+                          `C:\\Windows\\System32\\net.exe`,
+                          'use',
+                          'z:',
+                          `/DELETE`,
+                          `/YES`
+                        ],
+                        wait: true,
+                        hideWindow: true,
+                        username: machine.username
+                      })
+                        .then(() => {
+                          return PlazaService.exec(machine.ip, machine.plazaport, {
+                            command: [
+                              `C:\\Windows\\System32\\net.exe`,
+                              'use',
+                              'z:',
+                              `\\\\${storage.hostname}\\${storage.username}`,
+                              `/user:${storage.username}`,
+                              storage.password
+                            ],
+                            wait: true,
+                            hideWindow: true,
+                            username: machine.username
+                          });
+                        })
+                        .then(() => {
+                          return Promise.resolve();
+                        });
                     });
                 })
                 .then(() => {


### PR DESCRIPTION
Fixes #172 
When an image is created the storage configuration is saved for admin, when a regular user want to use this image the storage was corrupted, user can't access to his storage.

If we have a storage in `z:` now we delete it and recreate it. The storage is not corrupted anymore.
