### PR TITLE
Bugfix: Onboarding an app shows a black screen

### DIFF
--- a/assets/app/protected/apps/index/controller.js
+++ b/assets/app/protected/apps/index/controller.js
@@ -201,5 +201,10 @@ export default Ember.Controller.extend({
     openFileExplorer() {
       this.set('showFileExplorer', true);
     },
+
+    onboardAppSucceeded() {
+      this.send('refreshModel');
+      this.send('closeFileExplorer');
+    }
   }
 });

--- a/assets/app/protected/apps/index/template.hbs
+++ b/assets/app/protected/apps/index/template.hbs
@@ -45,7 +45,7 @@
   {{remote-session connectionName=connectionName activator=activator}}
 {{/single-tab}}
 
-{{dim-background show=showFileExplorer preventAction=isPublishing action="toggleFileExplorer"}}
+{{dim-background show=showFileExplorer preventAction=isPublishing action="closeFileExplorer"}}
 {{#floating-sidebar-component
   isVisible=showFileExplorer
 }}
@@ -55,7 +55,7 @@
     api="file"
     target='machines'
     system='windows'
-    action="refreshModel"
+    action="onboardAppSucceeded"
   }}
   {{/application-publisher}}
 {{/if}}


### PR DESCRIPTION
The screen turns black because dim-background is not closed properly after an app is onboarded.
To fix that, we ensure the component is closed
