### PR TITLE
Link groups with images instead of apps

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -47,10 +47,11 @@ module.exports = {
                  "app".id,
                  "app".alias,
                  "app"."displayName",
-                 "app"."filePath"
+                 "app"."filePath",
+                 "app"."image"
                  FROM "app"
-                 LEFT JOIN "appgroup" on appgroup.app = app.id
-                 LEFT JOIN "group" on appgroup.group = "group".id
+                 LEFT JOIN "imagegroup" on imagegroup.image = app.image
+                 LEFT JOIN "group" on imagegroup.group = "group".id
                  LEFT JOIN "usergroup" on usergroup.group = "group".id
                  WHERE usergroup.user = $1::varchar OR $2::boolean = true`,
         values: [
@@ -73,6 +74,7 @@ module.exports = {
       App.findOne({
         id: req.allParams().id
       })
+        .populate('image')
         .then((app) => {
           return res.ok(app);
         });
@@ -93,10 +95,30 @@ module.exports = {
 
     this._getApps(req.user)
       .then((apps) => {
-        return res.ok(apps.rows);
+        let appIds = _.map(apps.rows, 'id');
+
+        App.find(appIds)
+          .populate('image')
+          .then((apps) => {
+            return res.ok(apps);
+          });
       })
       .catch((err) => {
         return res.negotiate(err);
+      });
+  },
+
+  create(req, res) {
+
+    var values = JsonApiService.deserialize(req.body.data.attributes);
+
+    MachineService.getDefaultImage()
+      .then((defaultImage) => {
+
+        values.image = defaultImage.id;
+        App.create(values)
+          .then(res.created)
+          .catch(res.negotiate);
       });
   },
 

--- a/api/controllers/GroupController.js
+++ b/api/controllers/GroupController.js
@@ -33,7 +33,7 @@ module.exports = {
 
     Group.findOne(req.allParams().id)
       .populate('members')
-      .populate('apps')
+      .populate('images')
       .then(res.ok)
       .catch(res.negotiate);
   }

--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -22,7 +22,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* globals MachineService */
+/* globals MachineService, Image */
 
 const uuid = require('node-uuid');
 
@@ -39,6 +39,25 @@ module.exports = {
         });
       })
       .then(res.created)
+      .catch(res.negotiate);
+  },
+
+  findOne: function(req, res) {
+    Image.findOne({
+      id: req.allParams().id,
+      default: true
+    })
+      .populate('apps')
+      .then(res.ok)
+      .catch(res.negotiate);
+  },
+
+  find: function(req, res) {
+    Image.find({
+      default: true
+    })
+      .populate('apps')
+      .then(res.ok)
       .catch(res.negotiate);
   }
 };

--- a/api/drivers/driver.js
+++ b/api/drivers/driver.js
@@ -51,13 +51,14 @@ class Driver {
   }
 
   /*
-   * Return list of machines
+   * Create a machine from an image
    *
    * @method createMachine
-   * @param {Object} options model to be created
-   * @return {Promise[Machine]} Machine model created
+   * @param {Object[Machine]} properties worth to be passed along to the driver
+   * @param {Object[Image]} An image object the machine needs to be built from
+   * @return {Promise[Machine]} A promise resolving to the created machine
    */
-  createMachine(/* options */) {
+  createMachine(/*machine, image*/) {
     return Promise.reject(new Error('Driver\'s method "createMachine" not implemented'));
   }
 

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -132,11 +132,11 @@ class DummyDriver extends BaseDriver {
    * @param {Object} options model to be created
    * @return {Promise[Machine]} Machine model created
    */
-  createMachine(options) {
+  createMachine(machine) {
     const id = uuid.v4();
-    let machine = new Machine._model({
+    let machineToCreate = new Machine._model({
       id        : id,
-      name      : options.name,
+      name      : machine.name,
       type      : 'dummy',
       flavor    : 'dummy',
       ip        : _plazaAddress,
@@ -146,8 +146,8 @@ class DummyDriver extends BaseDriver {
       rdpPort   : 3389
     });
 
-    this._machines[machine.id] = machine;
-    return new Promise.resolve(machine);
+    this._machines[id] = machineToCreate;
+    return new Promise.resolve(machineToCreate);
   }
 
   destroyMachine(machine) {
@@ -172,18 +172,14 @@ class DummyDriver extends BaseDriver {
     return Machine.findOne(imageToCreate.buildFrom)
       .then((machine) => {
 
-        return Image.update({
-          default: true
-        }, {
+        let image = new Image._model({
           iaasId: uuid.v4(),
           name: imageToCreate.name,
           buildFrom: imageToCreate.buildFrom,
           password: machine.password
-        })
-          .then((images) => {
+        });
 
-            return images.pop();
-          });
+        return Promise.resolve(image);
       });
   }
 

--- a/api/migrations/023_create_imagegroup_table.js
+++ b/api/migrations/023_create_imagegroup_table.js
@@ -1,0 +1,93 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('imagegroup', (table) => {
+      table.increments();
+
+      table.string('image').references('image.id').onDelete('CASCADE').onUpdate('CASCADE');
+      table.string('group').references('group.id').onDelete('CASCADE').onUpdate('CASCADE');
+
+      table.unique(['image', 'group']);
+      table.dateTime('createdAt');
+      table.dateTime('updatedAt');
+    }),
+
+    knex.schema.table('machine', (machine) => {
+      machine.string('image').references('image.id');
+    })
+      .then(() => {
+        return knex.schema.table('app', (user) => {
+          user.string('image').references('image.id').onDelete('CASCADE').onUpdate('CASCADE');
+        });
+      })
+      .then(() => {
+        return knex('image').where({
+          default: true
+        });
+      })
+      .then((images) => {
+        if (images.length > 0) {
+          // We are able to assume there is only one image here
+          return Promise.all([
+            knex('app').update({
+              image: images[0].id
+            }),
+
+            knex('appgroup').select('*')
+              .then((appgroupRelations) => {
+                return Promise.map(appgroupRelations, function(appgroupRelation) {
+                  return knex.insert({
+                    image: images[0].id,
+                    group: appgroupRelation.group
+                  }).into('imagegroup');
+                });
+              }),
+          ]);
+        }
+      })
+      .then(() => {
+        return knex.schema.dropTable('appgroup', (user) => {
+          user.string('image').references('image.id').onDelete('CASCADE').onUpdate('CASCADE');
+        });
+      })
+  ]);
+}
+
+function down(knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('imagegroup'),
+
+    knex.schema.table('app', (table) => {
+      table.dropColumn('image');
+    }),
+
+    knex.schema.table('machine', (table) => {
+      table.dropColumn('image');
+    }),
+  ]);
+}
+
+module.exports = { up, down };

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -55,11 +55,8 @@ module.exports = {
     state: {
       type: 'string'
     },
-
-    groups: {
-      collection: 'group',
-      via: 'apps',
-      through: 'appgroup'
+    image: {
+      model: 'image',
     }
   }
 };

--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -44,16 +44,15 @@ module.exports = {
     name: {
       type: 'string'
     },
-
     members: {
       collection: 'user',
       via: 'groups',
       through: 'usergroup'
     },
-    apps: {
-      collection: 'app',
+    images: {
+      collection: 'image',
       via: 'groups',
-      through: 'appgroup'
+      through: 'imagegroup'
     }
   },
 

--- a/api/models/Image.js
+++ b/api/models/Image.js
@@ -22,6 +22,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+/* globals App */
+
 const uuid = require('node-uuid');
 
 module.exports = {
@@ -40,7 +42,7 @@ module.exports = {
       type: 'string'
     },
     buildFrom: {
-      type: 'string' // Actually the id of a machine that used to exist and served as base for this image (null if default image)
+      type: 'string'
     },
     default: {
       type: 'boolean'
@@ -48,6 +50,28 @@ module.exports = {
     password: {
       type: 'string',
       defaultsTo: null
+    },
+    groups: {
+      collection: 'group',
+      via: 'images',
+      through: 'imagegroup'
+    },
+    apps: {
+      collection: 'app',
+      via: 'image',
     }
+  },
+
+  afterCreate: function(values, next){
+    // Each image must have a "desktop" application by default
+    App.create({
+      alias: 'Desktop',
+      displayName: 'Desktop',
+      filePath: 'C:\\Windows\\explorer.exe',
+      image: values.id
+    })
+      .then(() => {
+        next();
+      });
   }
 };

--- a/api/models/ImageGroup.js
+++ b/api/models/ImageGroup.js
@@ -22,39 +22,13 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-import Ember from 'ember';
-import ArrayDiff from 'nanocloud/lib/array-diff';
-
-export default Ember.Controller.extend({
-  groupController: Ember.inject.controller('protected.users.groups.group'),
-  groupBinding: 'groupController.model',
-
-  actions: {
-    addApp(app) {
-      let group = this.get('group');
-
-      group.get('apps').pushObject(app);
-      group.save();
+module.exports = {
+  attributes: {
+    image: {
+      model: 'image'
     },
-
-    removeApp(app) {
-      let group = this.get('group');
-      let apps = group.get('apps');
-
-      apps.removeObject(app);
-      group.save();
+    group: {
+      model: 'group'
     }
-  },
-
-  reset() {
-    let applications = this.get('applications');
-    let apps = this.get('group.apps');
-
-    let availableApps = ArrayDiff.create({
-      major: applications,
-      minor: apps
-    });
-
-    this.set('availableApps', availableApps);
   }
-});
+};

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -74,6 +74,10 @@ module.exports = {
       model: 'user',
       unique: true
     },
+    image: {
+      model: 'image',
+      unique: true
+    },
     status: {
       type: 'string'
     },

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -72,7 +72,6 @@ module.exports = {
     team: {
       model: 'team'
     },
-
     groups: {
       collection: 'group',
       via: 'members',

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -21,7 +21,7 @@
  *
  */
 
-/* global ConfigService, Machine, Image, User, BrokerLog */
+/* global ConfigService, Machine, Image, User, BrokerLog, ImageGroup */
 
 const _ = require('lodash');
 const Promise = require('bluebird');
@@ -110,15 +110,15 @@ function initialize() {
             buildFrom: null,
             default: true
           })
-            .then(() => {
-              _driver = new (drivers[config.iaas])();
+          .then(() => {
+            _driver = new (drivers[config.iaas])();
 
-              return _driver.initialize()
-                .then(() => {
-                  _updateMachinesPool();
-                  return null;
-                });
-            });
+            return _driver.initialize()
+              .then(() => {
+                _updateMachinesPool();
+                return null;
+              });
+          });
         });
 
       return _initializing;
@@ -232,20 +232,22 @@ function increaseUsersMachineEndDate(user) {
  *  - machinesName: the name of the machine to be created
  *
  * @method _createMachine
+ * @param image {Object[Image]} image to build to machine from
  * @private
  * @return {Promise}
  */
-function _createMachine() {
+function _createMachine(image) {
 
   return ConfigService.get('machinesName')
     .then((config) => {
       return _driver.createMachine({
         name: config.machinesName
-      });
+      }, image);
     })
     .then((machine) => {
 
       machine.status = 'booting';
+      machine.image = image.id;
       _createBrokerLog(machine, 'Created');
       return Machine.create(machine);
     })
@@ -322,12 +324,13 @@ function _updateMachinesPool() {
         machineCount: Machine.count({
           status: 'running',
           user: null
-        })
+        }),
+        defaultImage: getDefaultImage()
       })
-        .then(({config, machineCount}) => {
+        .then(({config, machineCount, defaultImage}) => {
 
           let machineToCreate = config.machinePoolSize - machineCount;
-          let machines = _.times(machineToCreate, () => _createMachine());
+          let machines = _.times(machineToCreate, () => _createMachine(defaultImage));
 
           if (machineToCreate > 0) {
             _createBrokerLog({
@@ -474,7 +477,31 @@ function machines() {
  * @return {Promise[Image]} resolves to the new default image
  */
 function createImage(image) {
-  return _driver.createImage(image);
+  return _driver.createImage(image)
+    .then((newImage) => {
+
+      newImage.default = true;
+      return getDefaultImage()
+        .then((defaultImage) => {
+
+          return Image.update(defaultImage.id, {
+            default: false
+          })
+            .then(() => {
+              return Image.create(newImage);
+            })
+            .then((newImage) => {
+              return ImageGroup.update({
+                image: defaultImage.id
+              }, {
+                image: newImage.id
+              })
+                .then(() => {
+                  return Promise.resolve(newImage);
+                });
+            });
+        });
+    });
 }
 
 /*

--- a/assets/app/app/model.js
+++ b/assets/app/app/model.js
@@ -44,5 +44,6 @@ export default DS.Model.extend(Validations, {
   displayName: DS.attr('string'),
   filePath: DS.attr('string'),
   iconContent: DS.attr('string'),
+  image: DS.belongsTo(),
   path: DS.attr('string'),
 });

--- a/assets/app/group/model.js
+++ b/assets/app/group/model.js
@@ -28,5 +28,5 @@ export default DS.Model.extend({
   name: DS.attr('string'),
 
   members: DS.hasMany('user'),
-  apps: DS.hasMany('app'),
+  images: DS.hasMany('image'),
 });

--- a/assets/app/image/model.js
+++ b/assets/app/image/model.js
@@ -25,5 +25,12 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  name: DS.attr('string')
+  iaasId: DS.attr('string'),
+  name: DS.attr('string'),
+  buildFrom: DS.attr('string'),
+  default: DS.attr('boolean'),
+  password: DS.attr('string'),
+  createdAt: DS.attr('string'),
+
+  apps: DS.hasMany('app'),
 });

--- a/assets/app/protected/apps/index/controller.js
+++ b/assets/app/protected/apps/index/controller.js
@@ -177,7 +177,7 @@ export default Ember.Controller.extend({
     },
 
     startDesktop() {
-      var list = this.get('items').filterBy('alias', 'Desktop');
+      var list = this.get('items').filterBy('alias', 'Desktop').filterBy('image.default', true);
       if (list.length === 1) {
         var app = list.objectAt(0);
 

--- a/assets/app/protected/controller.js
+++ b/assets/app/protected/controller.js
@@ -75,7 +75,7 @@ export default Ember.Controller.extend({
     'protected.users.groups.index' : 'overview-of-the-users-tab#groups',
     'protected.users.groups.new' : 'create-a-new-group',
     'protected.users.groups.group.members' : 'add-remove-a-group-member',
-    'protected.users.groups.group.apps' : 'add-remove-an-application',
+    'protected.users.groups.group.image' : 'add-remove-an-application',
     'protected.users.groups.group.index' : 'rename-a-group',
     'protected.configs.index' : 'configure-sessions',
     'protected.configs.user-right' : 'configure-user-rights',

--- a/assets/app/protected/users/groups/group/controller.js
+++ b/assets/app/protected/users/groups/group/controller.js
@@ -30,7 +30,7 @@ export default Ember.Controller.extend({
   tab: [
     { title: 'General', link: 'protected.users.groups.group.index' },
     { title: 'Members', link: 'protected.users.groups.group.members' },
-    { title: 'Applications', link: 'protected.users.groups.group.apps' },
+    { title: 'Images', link: 'protected.users.groups.group.images' },
   ],
   selectedTab: Ember.computed('currentTab', 'currentTab', function() {
     return this.get('tab')[this.get('currentTab')].title;

--- a/assets/app/protected/users/groups/group/images/controller.js
+++ b/assets/app/protected/users/groups/group/images/controller.js
@@ -22,25 +22,39 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-function seed(knex) {
-  return knex.raw(`
-    INSERT INTO "app" (
-      "id",
-      "alias",
-      "displayName",
-      "filePath",
-      "createdAt", "updatedAt"
-    ) VALUES (
-      :id, :alias, :displayName, :filePath,
-      NOW(), NOW()
-    )
-    ON CONFLICT DO NOTHING
-  `, {
-    id: 'aff17b8b-bf91-40bf-ace6-6dfc985680bb',
-    alias: 'Desktop',
-    displayName: 'Desktop',
-    filePath: 'C:\\Windows\\explorer.exe'
-  });
-}
+import Ember from 'ember';
+import ArrayDiff from 'nanocloud/lib/array-diff';
 
-module.exports = { seed };
+export default Ember.Controller.extend({
+  groupController: Ember.inject.controller('protected.users.groups.group'),
+  groupBinding: 'groupController.model',
+
+  actions: {
+    addImage(image) {
+      let group = this.get('group');
+
+      group.get('images').pushObject(image);
+      group.save();
+    },
+
+    removeImage(image) {
+      let group = this.get('group');
+      let images = group.get('images');
+
+      images.removeObject(image);
+      group.save();
+    }
+  },
+
+  reset() {
+    let allImages = this.get('images');
+    let images = this.get('group.images');
+
+    let availableImages = ArrayDiff.create({
+      major: allImages,
+      minor: images
+    });
+
+    this.set('availableImages', availableImages);
+  }
+});

--- a/assets/app/protected/users/groups/group/images/route.js
+++ b/assets/app/protected/users/groups/group/images/route.js
@@ -26,11 +26,11 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   setupController(controller, model) {
-    controller.set('applications', model.toArray());
+    controller.set('images', model.filterBy('default', true).toArray());
     controller.reset();
   },
 
   model() {
-    return this.store.findAll('app', { reload : true });
+    return this.store.findAll('image', { reload : true });
   }
 });

--- a/assets/app/protected/users/groups/group/images/template.hbs
+++ b/assets/app/protected/users/groups/group/images/template.hbs
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6">
-    <h2>Manage applications</h2>
+    <h2>Manage images:</h2>
     <table class="table m-t-2">
       <thead>
         <tr>
@@ -9,17 +9,17 @@
         </tr>
       </thead>
       <tbody>
-        {{#each applications as |app|}}
+        {{#each images as |image|}}
           <tr>
             <td scope="row">
               <span class="link in-bl">
-                {{#link-to 'protected.apps.app' app}}
-                  {{app.displayName}}
+                {{#link-to 'protected.images.image' image}}
+                  {{image.name}}
                 {{/link-to}}
               </span>
             </td>
             <td>
-              {{toggle-item-from-list list=group.apps item=app property='id' addAction="addApp" removeAction="removeApp"}}
+              {{toggle-item-from-list list=group.images item=image property='id' addAction="addImage" removeAction="removeImage"}}
             </td>
           </tr>
         {{/each}}

--- a/assets/app/protected/users/groups/index/controller.js
+++ b/assets/app/protected/users/groups/index/controller.js
@@ -60,7 +60,7 @@ export default Ember.Controller.extend({
         id: item.get('id'),
         name: item.get('name'),
         members: item.get('members.length'),
-        apps: item.get('apps.length'),
+        images: item.get('images.length'),
       }));
     });
     this.set('data', ret);
@@ -82,8 +82,8 @@ export default Ember.Controller.extend({
       filterWithSelect: false
     },
     {
-      propertyName: 'apps',
-      title: 'Number of applications',
+      propertyName: 'images',
+      title: 'Number of images',
       disableFiltering: true,
       filterWithSelect: false
     },

--- a/assets/app/router.js
+++ b/assets/app/router.js
@@ -38,7 +38,7 @@ Router.map(function() {
       this.route('groups', function() {
         this.route('group', { path: '/:group_id' }, function() {
           this.route('members');
-          this.route('apps');
+          this.route('images');
         });
         this.route('new');
       });
@@ -55,6 +55,9 @@ Router.map(function() {
       this.route('app', { path: '/:app_id' });
     });
     this.route('apps');
+    this.route('images', function() {
+      this.route('image', { path: '/:image_id' });
+    });
     this.route('files', function() {
       this.route('nowindows');
     });

--- a/assets/tests/unit/protected/users/groups/group/apps/controller-test.js
+++ b/assets/tests/unit/protected/users/groups/group/apps/controller-test.js
@@ -24,7 +24,7 @@
 
 import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('controller:protected/users/groups/group/apps', 'Unit | Controller | protected/users/groups/group/apps', {
+moduleFor('controller:protected/users/groups/group/images', 'Unit | Controller | protected/users/groups/group/images', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/assets/tests/unit/protected/users/groups/group/apps/route-test.js
+++ b/assets/tests/unit/protected/users/groups/group/apps/route-test.js
@@ -24,7 +24,7 @@
 
 import { moduleFor, test } from 'ember-qunit';
 
-moduleFor('route:protected/users/groups/group/apps', 'Unit | Route | protected/users/groups/group/apps', {
+moduleFor('route:protected/users/groups/group/images', 'Unit | Route | protected/users/groups/group/images', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/api/group.test.js
+++ b/tests/api/group.test.js
@@ -23,7 +23,7 @@
  */
 
 // jshint mocha:true
-/* globals sails, Group */
+/* globals sails, Group, Image */
 
 var nano = require('./lib/nanotest');
 var chai = require('chai');
@@ -440,9 +440,9 @@ module.exports = function() {
       });
     });
 
-    describe('Add application to a group', function() {
+    describe('Add image to a group', function() {
 
-      it('Should return group with apps relationship', function(done) {
+      it('Should return group with images relationship', function(done) {
 
         var groupID = null;
 
@@ -451,7 +451,7 @@ module.exports = function() {
           .send({
             'data': {
               'attributes': {
-                'name': 'Group to add application to'
+                'name': 'Group to add image to'
               },
               'type': 'groups'
             }
@@ -462,38 +462,42 @@ module.exports = function() {
           .then((res) => {
 
             groupID = res.body.data.id;
-
-            return nano.request(sails.hooks.http.app)
-              .patch('/api/groups/' + groupID)
-              .send({
-                'data': {
-                  'id': groupID,
-                  'attributes': {
-                    'name': 'Group to add application to'
-                  },
-                  'relationships': {
-                    'apps': {
-                      'data': [{
-                        'type': 'apps',
-                        'id': nano.desktopId()
-                      }]
+            return Image.findOne({
+              default: true
+            })
+              .then((image) => {
+                return nano.request(sails.hooks.http.app)
+                  .patch('/api/groups/' + groupID)
+                  .send({
+                    'data': {
+                      'id': groupID,
+                      'attributes': {
+                        'name': 'Group to add image to'
+                      },
+                      'relationships': {
+                        'images': {
+                          'data': [{
+                            'type': 'images',
+                            'id': image.id
+                          }]
+                        }
+                      },
+                      'type': 'groups'
                     }
-                  },
-                  'type': 'groups'
-                }
-              })
-              .set(nano.adminLogin())
-              .expect(200)
-              .expect((res) => {
-                expect(res.body.data).to.be.an('object');
-              })
-              .expect(nano.jsonApiSchema(expectedSchema))
-              .expect(nano.jsonApiRelationship({
-                'apps': [{
-                  type: 'apps',
-                  id: nano.desktopId()
-                }]
-              }));
+                  })
+                  .set(nano.adminLogin())
+                  .expect(200)
+                  .expect((res) => {
+                    expect(res.body.data).to.be.an('object');
+                  })
+                  .expect(nano.jsonApiSchema(expectedSchema))
+                  .expect(nano.jsonApiRelationship({
+                    'images': [{
+                      type: 'images',
+                      id: image.id
+                    }]
+                  }));
+              });
           })
           .then(() => {
             return done();
@@ -501,9 +505,9 @@ module.exports = function() {
       });
     });
 
-    describe('Remove application from a group', function() {
+    describe('Remove image from a group', function() {
 
-      it('Should return group without any applications relationship', function(done) {
+      it('Should return group without any images relationship', function(done) {
 
         var groupID = null;
 
@@ -512,7 +516,7 @@ module.exports = function() {
           .send({
             'data': {
               'attributes': {
-                'name': 'Group to remove application from'
+                'name': 'Group to remove image access from'
               },
               'type': 'groups'
             }
@@ -524,37 +528,42 @@ module.exports = function() {
 
             groupID = res.body.data.id;
 
-            return nano.request(sails.hooks.http.app)
-              .patch('/api/groups/' + groupID)
-              .send({
-                'data': {
-                  'id': groupID,
-                  'attributes': {
-                    'name': 'Group to remove application from'
-                  },
-                  'relationships': {
-                    'apps': {
-                      'data': [{
-                        'type': 'apps',
-                        'id': nano.desktopId()
-                      }]
+            return Image.findOne({
+              default: true
+            })
+              .then((image) => {
+                nano.request(sails.hooks.http.app)
+                  .patch('/api/groups/' + groupID)
+                  .send({
+                    'data': {
+                      'id': groupID,
+                      'attributes': {
+                        'name': 'Group to remove image access from'
+                      },
+                      'relationships': {
+                        'images': {
+                          'data': [{
+                            'type': 'images',
+                            'id': image.id
+                          }]
+                        }
+                      },
+                      'type': 'groups'
                     }
-                  },
-                  'type': 'groups'
-                }
-              })
-              .set(nano.adminLogin())
-              .expect(200)
-              .expect((res) => {
-                expect(res.body.data).to.be.an('object');
-              })
-              .expect(nano.jsonApiSchema(expectedSchema))
-              .expect(nano.jsonApiRelationship({
-                'apps': [{
-                  type: 'apps',
-                  id: nano.desktopId()
-                }]
-              }));
+                  })
+                  .set(nano.adminLogin())
+                  .expect(200)
+                  .expect((res) => {
+                    expect(res.body.data).to.be.an('object');
+                  })
+                  .expect(nano.jsonApiSchema(expectedSchema))
+                  .expect(nano.jsonApiRelationship({
+                    'apps': [{
+                      type: 'apps',
+                      id: nano.desktopId()
+                    }]
+                  }));
+              });
           })
           .then(() => {
             return nano.request(sails.hooks.http.app)
@@ -566,7 +575,7 @@ module.exports = function() {
                     'name': 'Group to remove user from'
                   },
                   'relationships': {
-                    'apps': {
+                    'images': {
                       'data': []
                     }
                   },
@@ -580,7 +589,7 @@ module.exports = function() {
               })
               .expect(nano.jsonApiSchema(expectedSchema))
               .expect(nano.jsonApiRelationship({
-                'apps': []
+                'images': []
               }));
           })
           .then(() => {

--- a/tests/api/storage.test.js
+++ b/tests/api/storage.test.js
@@ -115,13 +115,13 @@ module.exports = function() {
     describe('Get user\'s team\'s files', function() {
       it('Should return an empty list (no team)', function(done) {
         nano.request(sails.hooks.http.app)
-        .get('/api/files?teams=true')
-        .set(nano.adminLogin())
-        .expect(200)
-        .expect(nano.jsonApiSchema(fileSchema))
-        .expect((res) => {
-          expect(res.body.data.length).to.equal(0);
-        })
+          .get('/api/files?teams=true')
+          .set(nano.adminLogin())
+          .expect(200)
+          .expect(nano.jsonApiSchema(fileSchema))
+          .expect((res) => {
+            expect(res.body.data.length).to.equal(0);
+          })
         .end(done);
       });
     });
@@ -129,16 +129,16 @@ module.exports = function() {
     describe('Create directory', function() {
       it('Should create a directory', function(done) {
         nano.request(sails.hooks.http.app)
-        .post('/api/files?filename=./test')
-        .set(nano.adminLogin())
-        .expect(200)
-        .expect(nano.jsonApiSchema(fileSchema))
-        .expect((res) => {
-          expect(res.body.data.length).to.equal(2);
-          expect(res.body.data[1].attributes.type).to.equal('directory');
-          expect(res.body.data[1].attributes.name).to.equal('test');
-        })
-        .end(done);
+          .post('/api/files?filename=./test')
+          .set(nano.adminLogin())
+          .expect(200)
+          .expect(nano.jsonApiSchema(fileSchema))
+          .expect((res) => {
+            expect(res.body.data.length).to.equal(2);
+            expect(res.body.data[1].attributes.type).to.equal('directory');
+            expect(res.body.data[1].attributes.name).to.equal('test');
+          })
+          .end(done);
       });
     });
 


### PR DESCRIPTION
Fixes #191 
Inspired from https://github.com/Nanocloud/nanocloud/pull/241

Groups link users and images
App belong to an image
Desktop is a default app for all images
Adapt frontend to link images to users through groups

Co-authored-by Romain Soufflet romain.soufflet@nanocloud.com
