### PR TITLE
Get sessions catch now return an empty array, so broker can scale down.

### DIFF
--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -134,8 +134,10 @@ module.exports = {
           return sessions;
         })
         // If timeout is exceeded, machine is probably booting or being shut-down
-        // Let's ignore the error silently
-        .catch(() => {});
+        // Let's ignore the error silently and return an empty array.
+        .catch(() => {
+          return ([]);
+        });
     },
 
     /*


### PR DESCRIPTION
Fixe #275 
Now the catch return an empty array if the machine is
booting or being shut-down.
