### PR TITLE
Fix: In machine page, the text is wrong when there are no machines available.

### DIFF
--- a/assets/app/protected/machines/index/template.hbs
+++ b/assets/app/protected/machines/index/template.hbs
@@ -16,7 +16,7 @@
   {{#unless loadState}}
     {{#if modelIsEmpty}}
       <div class="alert alert-info" role="alert">
-        <strong>Looks like you haven’t uploaded any file yet! Drag and drop any file here to upload it.</strong>
+        <strong>No machine is currently available! Just wait a couple of minutes and available machines will appear!</strong>
       </div>
     {{else}}
       {{models-table


### PR DESCRIPTION
-> "No machine is currently available! Just wait a couple of minutes and available machines will appear!"

Fixes #272 
