### PR TITLE
Bugfix: In machine page, assigned-to column is too large when username is long

### DIFF
--- a/assets/app/protected/machines/index/table/machine-list/assigned-to/template.hbs
+++ b/assets/app/protected/machines/index/table/machine-list/assigned-to/template.hbs
@@ -1,5 +1,5 @@
 {{#if record.user}}
-  {{#link-to 'protected.users.user' record.user.id}}
+  {{#link-to 'protected.users.user' record.user.id class="truncate"}}
     {{record.user.fullName}}
   {{/link-to}}
 {{else}}

--- a/assets/app/protected/template.hbs
+++ b/assets/app/protected/template.hbs
@@ -152,7 +152,7 @@
       <ul class="nav navbar-nav pull-xs-right">
         <li class="nav-item">
           <div class="dropdown logout-dropdown">
-            <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">
+            <button class="btn btn-secondary dropdown-toggle truncate" type="button" data-toggle="dropdown">
               {{session.user.fullName}}
               <span class="caret"></span>
             </button>

--- a/assets/app/styles/menu-top.scss
+++ b/assets/app/styles/menu-top.scss
@@ -13,6 +13,10 @@
   &:hover{
     background-color: $gray-lighter;
   }
+  
+  button.dropdown-toggle {
+    width: 200px;
+  }
 
   > .dropdown-menu {
     margin-top: 0;


### PR DESCRIPTION
To fix that, we set a width limit to the column 'assigned-to' 
