### PR TITLE
AWS credit used can't exceed 4 decimals.

### DIFF
--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -451,7 +451,7 @@ class AWSDriver extends Driver {
             });
           })
           .then(() => {
-            return resolve(finalPrice);
+            return resolve(parseFloat(finalPrice.toFixed(4)));
           })
           .catch((err) => {
             return reject(err);


### PR DESCRIPTION
Fixe #283 
To resolve this, we take the first four decimals.
