### PR TITLE
Add the stop/start options on drivers.

### DIFF
--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -71,15 +71,23 @@ module.exports = {
 
   update(req, res) {
 
-    if (req.body.data.attributes.status === 'rebooting') {
+    var status = req.body.data.attributes.status;
+    if (status === 'rebooting' || status === 'stop' || status === 'start') {
       return Machine.findOne({
-        id: req.body.data.id
+        id: (status === 'rebooting') ? req.body.data.id : req.params.id
       })
         .then((machine) => {
-          return machine.reboot();
+          if (status === 'rebooting') {
+            machine.reboot();
+            return machine;
+          } else if (status === 'start') {
+            return MachineService.startMachine(machine);
+          } else if (status === 'stop') {
+            return MachineService.stopMachine(machine);
+          }
         })
-        .then(() => {
-          return res.ok();
+        .then((machine) => {
+          return res.ok(machine);
         })
         .catch((err) => {
           res.status = 400;
@@ -106,42 +114,6 @@ module.exports = {
         } else {
           return res.negotiate(err);
         }
-      });
-  },
-
-  /**
-   * @methods start
-   */
-  start(req, res) {
-    Machine.findOne({
-      id: req.params.id
-    })
-      .then((machine) => {
-        return MachineService.startMachine(machine);
-      })
-      .then((machine) => {
-        return res.ok(machine);
-      })
-      .catch((err) => {
-        return res.send(400, err);
-      });
-  },
-
-  /**
-   * @method stop
-   */
-  stop(req, res) {
-    Machine.findOne({
-      id: req.params.id
-    })
-      .then((machine) => {
-        return MachineService.stopMachine(machine);
-      })
-      .then((machine) => {
-        return res.ok(machine);
-      })
-      .catch((err) => {
-        return res.send(400, err);
       });
   }
 };

--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -72,7 +72,7 @@ module.exports = {
   update(req, res) {
 
     var status = req.body.data.attributes.status;
-    if (status === 'rebooting' || status === 'stop' || status === 'start') {
+    if (status === 'rebooting' || status === 'stopping' || status === 'starting') {
       return Machine.findOne({
         id: (status === 'rebooting') ? req.body.data.id : req.params.id
       })
@@ -80,9 +80,9 @@ module.exports = {
           if (status === 'rebooting') {
             machine.reboot();
             return machine;
-          } else if (status === 'start') {
+          } else if (status === 'starting') {
             return MachineService.startMachine(machine);
-          } else if (status === 'stop') {
+          } else if (status === 'stopping') {
             return MachineService.stopMachine(machine);
           }
         })

--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -107,5 +107,41 @@ module.exports = {
           return res.negotiate(err);
         }
       });
+  },
+
+  /**
+   * @methods start
+   */
+  start(req, res) {
+    Machine.findOne({
+      id: req.params.id
+    })
+      .then((machine) => {
+        return MachineService.startMachine(machine);
+      })
+      .then((machine) => {
+        return res.ok(machine);
+      })
+      .catch((err) => {
+        return res.send(400, err);
+      });
+  },
+
+  /**
+   * @method stop
+   */
+  stop(req, res) {
+    Machine.findOne({
+      id: req.params.id
+    })
+      .then((machine) => {
+        return MachineService.stopMachine(machine);
+      })
+      .then((machine) => {
+        return res.ok(machine);
+      })
+      .catch((err) => {
+        return res.send(400, err);
+      });
   }
 };

--- a/api/drivers/driver.js
+++ b/api/drivers/driver.js
@@ -61,6 +61,28 @@ class Driver {
     return Promise.reject(new Error('Driver\'s method "createMachine" not implemented'));
   }
 
+  /*
+   * Stop the specified machine
+   *
+   * @method stopMachine
+   * @param {Object} machine to be stopped
+   * @return {Promise[Machine]} Machine model stopped
+   */
+  stopMachine(/* machine */) {
+    return Promise.reject(new Error('Driver\'s method "stopMachine" not implemented'));
+  }
+
+  /*
+   * Start the specified machine
+   *
+   * @method stopMachine
+   * @param {Object} machine to be started
+   * @return {Promise[Machine]} Machine model started
+   */
+  startMachine(/* machine */) {
+    return Promise.reject(new Error('Driver\'s method "startMachine" not implemented'));
+  }
+
   destroyMachine(/* machine */) {
     return Promise.reject(new Error('Driver\'s method "destroyMachine" not implemented'));
   }

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -150,6 +150,26 @@ class DummyDriver extends BaseDriver {
     return new Promise.resolve(machine);
   }
 
+  /**
+   * Start the specified machine.
+   *
+   * @method startMachine
+   * @return {Promise[Object]}
+   */
+  startMachine(machine) {
+    return Promise.resolve(machine);
+  }
+
+  /**
+   * Stop the specified machine.
+   *
+   * @method stopMachine
+   * @return {Promise}
+   */
+  stopMachine(machine) {
+    return Promise.resolve(machine);
+  }
+
   destroyMachine(machine) {
     if (this._machines.hasOwnProperty(machine.id)) {
       delete this._machines[machine.id];
@@ -245,6 +265,9 @@ class DummyDriver extends BaseDriver {
     return new Promise((resolve, reject) => {
       if (machine.status === 'error') {
         reject(machine.status);
+      } else if (machine.status === 'stopping') {
+        machine.status = 'stopped';
+        return resolve(machine);
       }
       machine.status = 'running';
       return resolve(machine);

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -395,6 +395,9 @@ function stopMachine(machine) {
         }, machineStopped);
       })
       .then((machines) => {
+        if (!machines[0].user) {
+          _updateMachinesPool();
+        }
         return (machines[0]);
       });
   } else {

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -288,6 +288,122 @@ function _createMachine() {
     });
 }
 
+/**
+ * Ask the driver to start the specified machine
+ *
+ * @method startMachine
+ * @public
+ * @return {Promise[Machine]}
+ */
+function startMachine(machine) {
+
+  if (_driver.startMachine) {
+    return _driver.startMachine(machine)
+      .then((machineStarting) => {
+        machineStarting.status = 'starting';
+
+        return Machine.update({
+          id: machineStarting.id
+        }, machineStarting);
+      })
+      .then((machines) => {
+        return promisePoller({
+          taskFn: () => {
+            return machines[0].refresh()
+              .then((machineRefreshed) => {
+                if (machineRefreshed.status === 'running') {
+                  return Promise.resolve(machineRefreshed);
+                } else {
+                  return Promise.reject(machineRefreshed);
+                }
+              });
+          },
+          interval: 5000,
+          retries: 100
+        })
+          .catch((errs) => { // If timeout is reached
+
+            let machine = errs.pop(); // On timeout, promisePoller rejects with an array of all rejected promises. In our case, MachineService rejects the still booting machine. Let's pick the last one.
+
+            _createBrokerLog(machine, 'Error waiting to start machine');
+            _terminateMachine(machine);
+            throw machine;
+          });
+      })
+      .then((machineStarted) => {
+        _createBrokerLog(machineStarted, 'Started');
+        return Machine.update({
+          id: machine.id
+        }, machineStarted);
+      })
+      .then((machines) => {
+        return (machines[0]);
+      });
+  } else {
+    return new Promise((resolve, reject) => {
+      return reject('Start machine feature is not available on this driver');
+    });
+  }
+}
+
+/**
+ * Ask the driver to stop the specified machine
+ *
+ * @method stopMachine
+ * @public
+ * @return {Promise[Machine]}
+ */
+function stopMachine(machine) {
+
+  if (_driver.stopMachine) {
+    return _driver.stopMachine(machine)
+      .then(() => {
+        machine.status = 'stopping';
+        return Machine.update({
+          id: machine.id
+        }, machine);
+      })
+      .then((machines) => {
+        return promisePoller({
+          taskFn: () => {
+            return machines[0].refresh()
+              .then((machineRefreshed) => {
+
+                if (machineRefreshed.status === 'stopped') {
+                  return Promise.resolve(machineRefreshed);
+                } else {
+                  return Promise.reject(machineRefreshed);
+                }
+              });
+          },
+          interval: 5000,
+          retries: 100
+        })
+          .catch((errs) => { // If timeout is reached
+
+            let machine = errs.pop(); // On timeout, promisePoller rejects with an array of all rejected promises. In our case, MachineService rejects the still booting machine. Let's pick the last one.
+
+            _createBrokerLog(machine, 'Error waiting to stop machine');
+            _terminateMachine(machine);
+            throw machine;
+          });
+      })
+      .then((machineStopped) => {
+        _createBrokerLog(machineStopped, 'Stopped');
+        return Machine.update({
+          id: machine.id
+        }, machineStopped);
+      })
+      .then((machines) => {
+        return (machines[0]);
+      });
+  } else {
+    return new Promise((resolve, reject) => {
+      return reject('Stop machine feature is not available on this driver');
+    });
+  }
+}
+
 function _terminateMachine(machine) {
 
   if (_driver.destroyMachine) {
@@ -575,5 +691,6 @@ function rebootMachine(machine) {
 
 module.exports = {
   initialize, getMachineForUser, driverName, sessionOpen, sessionEnded,
-  machines, createImage, getDefaultImage, refresh, getPassword, rebootMachine
+  machines, createImage, getDefaultImage, refresh, getPassword,
+  rebootMachine, startMachine, stopMachine,
 };

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -337,6 +337,9 @@ function startMachine(machine) {
         }, machineStarted);
       })
       .then((machines) => {
+        if (machines[0].user) {
+          increaseUsersMachineEndDate({id: machines[0].user});
+        }
         return (machines[0]);
       });
   } else {

--- a/assets/app/machine/model.js
+++ b/assets/app/machine/model.js
@@ -52,4 +52,10 @@ export default DS.Model.extend({
     return this.get('name') || 'No name';
   }),
   user: DS.belongsTo('user'),
+  isStopped: Ember.computed('status', function() {
+    return (this.get('status') === 'stopping' || this.get('status') === 'stopped');
+  }),
+  isStarting: Ember.computed('status', function() {
+    return (this.get('status') === 'starting');
+  }),
 });

--- a/assets/app/protected/machines/index/controller.js
+++ b/assets/app/protected/machines/index/controller.js
@@ -65,6 +65,8 @@ export default Ember.Controller.extend({
         status: item.get('status'),
         user: item.get('user'),
         endDate: item.get('endDate'),
+        stopped: item.get('isStopped'),
+        starting: item.get('isStarting'),
       }));
     });
     this.set('data', ret);

--- a/assets/app/protected/machines/index/table/machine-list/expiration/template.hbs
+++ b/assets/app/protected/machines/index/table/machine-list/expiration/template.hbs
@@ -5,7 +5,13 @@
     This machine will be terminated soon.
   {{/if}}
 {{else if record.user}}
-  <span class='color-success'>Currently in use</span>
+  {{#if record.stopped}}
+    -
+  {{else if record.starting}}
+    -
+  {{else}}
+    <span class='color-success'>Currently in use</span>
+  {{/if}}
 {{else}}
   -
 {{/if}}

--- a/assets/app/styles/light-bulb.scss
+++ b/assets/app/styles/light-bulb.scss
@@ -34,7 +34,7 @@
       @extend .booting;
     }
 
-    &.booting, &.rebooting {
+    &.booting, &.rebooting, &.starting {
       background-color: #F4B835;
       box-shadow: 0px 0px 1px #F4B835;
       @extend .transition-enabled;
@@ -55,6 +55,11 @@
     &.downloading {
       background-color: #8EDAFB;
       box-shadow: 0px 0px 1px #8EDAFB;
+    }
+
+    &.stopped {
+      background-color: red;
+      box-shadow: 0px 0px 1px red;
     }
   }
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -125,6 +125,16 @@ module.exports.routes = {
     action: 'findOne'
   },
 
+  'POST /machines/start/:id': {
+    controller: 'Machine',
+    action: 'start'
+  },
+
+  'POST /machines/stop/:id': {
+    controller: 'Machine',
+    action: 'stop'
+  },
+
   'GET /machines/users': {
     controller: 'Machine',
     action: 'users'

--- a/config/routes.js
+++ b/config/routes.js
@@ -125,16 +125,6 @@ module.exports.routes = {
     action: 'findOne'
   },
 
-  'POST /machines/start/:id': {
-    controller: 'Machine',
-    action: 'start'
-  },
-
-  'POST /machines/stop/:id': {
-    controller: 'Machine',
-    action: 'stop'
-  },
-
   'GET /machines/users': {
     controller: 'Machine',
     action: 'users'

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -611,7 +611,7 @@ paths:
           format: uuid
         - in: body
           name: data
-          description: machine with attribute status set to 'rebooting', 'stop' or 'start'
+          description: machine with attribute status set to 'rebooting', 'stopping' or 'starting'
           required: true
           schema:
             $ref: "#/definitions/Machines"

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -572,6 +572,52 @@ paths:
                   "$ref": "#/definitions/Machines"
         401:
           description: Unauthorized if no token without an access token
+  /machines/start/{id}:
+    post:
+      tags:
+        - machines
+      summary:
+        Start the specified machine
+      parameters:
+        - in: path
+          name: id
+          description: Machine id
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: Return the specified machine updated
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/Machines"
+  /machines/stop/{id}:
+    post:
+      tags:
+        - machines
+      summary:
+        Stop the specified machine
+      parameters:
+        - in: path
+          name: id
+          description: Machine id
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: Return the specified machine updated
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/Machines"
   /machines/{id}:
     get:
       tags:

--- a/docs/nanocloud-api.yml
+++ b/docs/nanocloud-api.yml
@@ -572,52 +572,6 @@ paths:
                   "$ref": "#/definitions/Machines"
         401:
           description: Unauthorized if no token without an access token
-  /machines/start/{id}:
-    post:
-      tags:
-        - machines
-      summary:
-        Start the specified machine
-      parameters:
-        - in: path
-          name: id
-          description: Machine id
-          required: true
-          type: string
-          format: uuid
-      responses:
-        200:
-          description: Return the specified machine updated
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  "$ref": "#/definitions/Machines"
-  /machines/stop/{id}:
-    post:
-      tags:
-        - machines
-      summary:
-        Stop the specified machine
-      parameters:
-        - in: path
-          name: id
-          description: Machine id
-          required: true
-          type: string
-          format: uuid
-      responses:
-        200:
-          description: Return the specified machine updated
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  "$ref": "#/definitions/Machines"
   /machines/{id}:
     get:
       tags:
@@ -657,7 +611,7 @@ paths:
           format: uuid
         - in: body
           name: data
-          description: machine with attribute status set to 'rebooting'
+          description: machine with attribute status set to 'rebooting', 'stop' or 'start'
           required: true
           schema:
             $ref: "#/definitions/Machines"

--- a/docs/nanocloud-qemu.yml
+++ b/docs/nanocloud-qemu.yml
@@ -28,11 +28,55 @@ paths:
           description: A VM is booting
         400:
           description: Machine description is missing or incomplete
-
-  /machines/{machine_uuid}:
-    delete:
+          
+  /machines/status/{machine_uuid}:
+    get:
       summary:
-        Stop specified VM. This won't delete it
+        Get the status of the specified machine
+      parameters:
+        - in: path
+          name: machine_uuid
+          description: Machine's UUID
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: VM status
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/MachineStatus"
+          
+  /machines/start/{machine_uuid}:
+    post:
+      summary:
+        Get the status of the specified machine
+      parameters:
+        - in: path
+          name: machine_uuid
+          description: Machine's UUID
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: VM has been started
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/MachineStatus"
+          
+  /machines/stop/{machine_uuid}:
+    post:
+      summary:
+        Get the status of the specified machine
       parameters:
         - in: path
           name: machine_uuid
@@ -49,7 +93,29 @@ paths:
               data:
                 type: array
                 items:
-                  "$ref": "#/definitions/MachineDeleted"
+                  "$ref": "#/definitions/MachineStatus"
+
+  /machines/{machine_uuid}:
+    delete:
+      summary:
+        Stop specified VM. This won't delete it
+      parameters:
+        - in: path
+          name: machine_uuid
+          description: Machine's UUID
+          required: true
+          type: string
+          format: uuid
+      responses:
+        200:
+          description: VM has been deleted
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  "$ref": "#/definitions/MachineStatus"
         404:
           description: No machine found with this UUID
   /images:
@@ -85,7 +151,7 @@ definitions:
         type: number
       plazaPort:
         type: number
-  MachineDeleted:
+  MachineStatus:
     type: object
     properties:
       id:

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -233,6 +233,72 @@ describe('Machine Service', () => {
         });
     });
 
+    it('Should stop machine', (done) => {
+      return MachineService.getMachineForUser({
+        id: adminId,
+        name: 'Admin'
+      })
+        .then((machine) => {
+          return MachineService.stopMachine(machine)
+            .then((machineStopped) => {
+              assert.equal(machineStopped.id, machine.id);
+              assert.equal(machineStopped.user, machine.user);
+              assert.equal(machineStopped.status, 'stopped');
+              return;
+            })
+            .then(() => {
+              return setTimeout(function() {
+                return BrokerLog.findOne({
+                  machineId: machine.id,
+                  state: 'Stopped'
+                })
+                  .then((log) => {
+                    assert.equal(log.state, 'Stopped');
+                    assert.equal(log.machineId, machine.id);
+                    assert.equal(log.userId, adminId);
+                    return;
+                  })
+                  .then(() => {
+                    return done();
+                  });
+              }, 100); // give broker time to log the machine state
+            });
+        });
+    });
+
+    it('Should start machine', (done) => {
+      return MachineService.getMachineForUser({
+        id: adminId,
+        name: 'Admin'
+      })
+        .then((machine) => {
+          return MachineService.startMachine(machine)
+            .then((machineStarted) => {
+              assert.equal(machineStarted.id, machine.id);
+              assert.equal(machineStarted.user, machine.user);
+              assert.equal(machineStarted.status, 'running');
+              return;
+            })
+            .then(() => {
+              return setTimeout(function() {
+                return BrokerLog.findOne({
+                  machineId: machine.id,
+                  state: 'Started'
+                })
+                  .then((log) => {
+                    assert.equal(log.state, 'Started');
+                    assert.equal(log.machineId, machine.id);
+                    assert.equal(log.userId, adminId);
+                    return;
+                  })
+                  .then(() => {
+                    return done();
+                  });
+              }, 100);
+            });
+        });
+    });
+
     it('Should terminate machine if no connection occured after the maximum session duration time', (done) => {
       return MachineService.getMachineForUser({
         id: adminId,


### PR DESCRIPTION
Fixes #293 

Add stop/startMachine methods on AWS, Qemu, Dummy drivers.

Stop will not destroy the machine, she will just stop taking resources.
Start on a stopped machine will rerun her, so she can be reused.
