### PR TITLE
Add live modification of the pool size

### DIFF
--- a/api/controllers/ConfigController.js
+++ b/api/controllers/ConfigController.js
@@ -25,7 +25,7 @@
  * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
 
-/* globals Config, ConfigService */
+/* globals Config, ConfigService, MachineService */
 
 module.exports = {
 
@@ -36,16 +36,19 @@ module.exports = {
 
     ConfigService.set(key, value)
       .then(() => {
+        if (key === 'machinePoolSize') {
+          MachineService.updateMachinesPool();
+        }
         Config.find({
           key : key
         })
-        .then((createdEntry) => {
-          return res.ok(createdEntry);
-        });
+          .then((createdEntry) => {
+            return res.ok(createdEntry);
+          });
       })
-    .catch((err) => {
-      return res.negotiate(err);
-    });
+      .catch((err) => {
+        return res.negotiate(err);
+      });
   },
 
   find: function(req, res) {

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -49,6 +49,7 @@ export default Ember.Service.extend({
     'teamEnabled',
     'machinesName',
     'neverTerminateMachine',
+    'machinePoolSize'
   ],
   keyToBeRetrievedAsString: Ember.computed('keyToBeRetrieved', function() {
     let params = this.get('keyToBeRetrieved');

--- a/assets/app/protected/configs/index/template.hbs
+++ b/assets/app/protected/configs/index/template.hbs
@@ -1,8 +1,12 @@
-<div class='content-wrapper m-t-1'>
-  <p class="color-primary in-bl fl m-t-1">
-    <span class='session-expired'>
-    <span class="va-sup">Session duration (seconds)</span>
-    {{input-confirm class="in-bl va-bottom" placeholder=configController.sessionDuration value=configController.sessionDuration type="number"}}
-    </span>
-  </p>
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p class="confirm-input-item color-primary in-bl fl">Session duration (seconds)</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm class="in-bl va-bottom" placeholder=configController.sessionDuration value=configController.sessionDuration type="number"}}</div>
+</div>
+<div class="form-group row">
+  <div class="col-sm-2">
+    <p  class="confirm-input-item color-primary in-bl fl">Machine pool size</p>
+  </div>
+  <div class="col-sm-3">{{input-confirm class="in-bl va-bottom" placeholder=configController.machinePoolSize value=configController.machinePoolSize type="number"}}</div>
 </div>


### PR DESCRIPTION
Fixes #296 
You can change the machine pool size from the config tab.
When `machinePoolSize` is changed, now the number of machine in the pool is automatically updated.
If there is not enough machines, some starts.
In the opposite case, if the number of running machine is superior of the pool size, no machine will be destroyed.

Add unit test for `updateMachinesPool`.
