### PR TITLE
Bugfix: element not well positioned, team setting has wrong behavior, setting defaultGroup generate unexpected error

### DIFF
--- a/assets/app/components/application-publisher/template.hbs
+++ b/assets/app/components/application-publisher/template.hbs
@@ -6,7 +6,7 @@
         {{icon-component class="va-sub" materialIcon="help"}} 
       {{/nano-tooltip}}
     </h4>
-      <ol class="breadcrumb">
+      <ol class="breadcrumb truncate">
         {{#each historyData as |item index|}}
           <li class='clickable'><a {{ action "moveOffset" index}}>{{ item }}</a></li>
         {{/each}} 

--- a/assets/app/protected/configs/controller.js
+++ b/assets/app/protected/configs/controller.js
@@ -70,7 +70,7 @@ export default Ember.Controller.extend({
   actions: {
     selectGroup(id) {
       if (this.get('defaultGroup') === id) {
-        this.set('defaultGroup', null);
+        this.set('defaultGroup', false);
       }
       else {
         this.set('defaultGroup', id);

--- a/assets/app/protected/users/index/table/user-list/team-setting/template.hbs
+++ b/assets/app/protected/users/index/table/user-list/team-setting/template.hbs
@@ -1,19 +1,22 @@
 {{record.team.name}}
-<div class='rel in-bl fright' {{ action toggleUserSetting record }}>
-  {{icon-component class='va-sub color-primary clickable' hover-darker=true materialIcon='settings' size=16}}
-  {{#if record.teamOptionIsOpen}}
-    {{#popup-component isOpen=record.teamOptionIsOpen close=closePopup position="left"}}
-    <div class="list-group">
-      <a href="#" class="list-group-item list-group-item-action unclickable active"><span class='va-tb'>Teams</span></a>
-      {{#each targetObject.teams as |team|}}
-      <a href="#" class="list-group-item list-group-item-action" {{ action changeUserTeam record team }} >{{team.name}}
-        {{#if (is-equal team.id record.team.id)}}
-        {{icon-component materialIcon='done' class='color-primary in-bl va-sub fright' size=16}}
-        {{/if}}
-      </a>
-      {{/each}}
-    </div>
-    {{/popup-component}}
-  {{/if}}
-</div>
-{{dim-background show=record.teamOptionIsOpen action=(action closePopup record) opacity=0.2 duration=500}}
+{{#if targetObject.teams.length}}
+  <div class='rel in-bl fright' {{ action toggleUserSetting record }}>
+      {{icon-component class='va-sub color-primary clickable' hover-darker=true materialIcon='settings' size=16}}
+      {{#if record.teamOptionIsOpen}}
+        {{#popup-component isOpen=record.teamOptionIsOpen close=closePopup position="left"}}
+        <div class="list-group">
+          <a href="#" class="list-group-item list-group-item-action unclickable active"><span class='va-tb'>Teams</span></a>
+          {{#each targetObject.teams as |team|}}
+          <a href="#" class="list-group-item list-group-item-action" {{ action changeUserTeam record team }} >{{team.name}}
+            {{#if (is-equal team.id record.team.id)}}
+            {{icon-component materialIcon='done' class='color-primary in-bl va-sub fright' size=16}}
+            {{/if}}
+          </a>
+          {{/each}}
+        </div>
+        {{/popup-component}}
+      {{/if}}
+  </div>
+{{else}}
+  {{icon-component class='va-sub' materialIcon='close' size=16}}
+{{/if}}

--- a/assets/app/protected/users/teams/index/controller.js
+++ b/assets/app/protected/users/teams/index/controller.js
@@ -26,14 +26,11 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-  /* global $:false */
   download: Ember.inject.service('download'),
   session: Ember.inject.service('session'),
   teamController: Ember.inject.controller('protected.users.teams'),
   protectedController: Ember.inject.controller('protected'),
   teams: Ember.computed.oneWay('teamController.teams'),
-  dimBackground: Ember.computed.and('focusModeTeams', 'protectedController.hasNoTeam'),
-  focusModeTeams: false,
   loadState: false,
   items: null,
   showFileExplorer: false,
@@ -96,18 +93,6 @@ export default Ember.Controller.extend({
             this.set('loadState', true);
             this.get('model').save()
               .then((team) => {
-                this.set('focusModeTeams', false);
-                $('.teams-focus-input').velocity(
-                  {
-                    opacity: 0,
-                    right: '100%',
-                    position: 'absolute'
-                  },
-                  {
-                    easing: 'easeOutQuart',
-                    duration: 700,
-                    visibility: 'hidden',
-                  });
                 this.toast.success('Team has been created successfully');
                 this.get('session.user').set('team', team);
                 this.get('session.user').set('isTeamAdmin', true);
@@ -139,10 +124,6 @@ export default Ember.Controller.extend({
 
     togglePopup(user) {
       user.toggleProperty('teamOptionIsOpen');
-    },
-
-    closeFocusModeTeams() {
-      this.set('focusModeTeams', false);
     },
 
     toAdminTeam(user) {

--- a/assets/app/styles/file-explorer.scss
+++ b/assets/app/styles/file-explorer.scss
@@ -11,6 +11,11 @@
 
   .breadcrumb {
     font-size: 16px;
+
+    > li {
+      float: none;
+      display: inline !important;
+    }
   }
 
   .section {

--- a/assets/app/styles/global.scss
+++ b/assets/app/styles/global.scss
@@ -18,9 +18,9 @@ h1 {
 
 .main-navbar {
   position: fixed;
-  right: 0;
+  right: 15px;
   top: 0;
-  width: calc(100% - 250px);
+  width: calc(100% - 265px);
   z-index: 1;
 }
 
@@ -39,7 +39,6 @@ h1 {
 
 .content-wrapper {
   margin: 0px 0px 20px 0px;
-  height: 100%;
 }
 
 .loading-page {

--- a/assets/app/styles/sidebar.scss
+++ b/assets/app/styles/sidebar.scss
@@ -9,11 +9,11 @@
 .main-content {
   position: relative;
   width: calc(100% - 250px);
+  height: 100%;
   float: right;
   padding: 40px 20px 0px 20px;
   overflow: auto;
   max-height: 100%;
-  height: 100%;
   -webkit-transition-property: top,bottom;
   transition-property: bottom;
   -webkit-transition-duration: .2s,.2s;

--- a/assets/app/styles/sortable-table.scss
+++ b/assets/app/styles/sortable-table.scss
@@ -25,6 +25,9 @@
   td {
     border: 1px solid $blue-lighter;
     vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   tr {


### PR DESCRIPTION
- remove dim background when opening team setting in user page
- setting button in user page should not work when there are no teams
- publish button is not well positioned when breadcrumb content wrap into two lines
- useless vertical scroll in machine and broker log page
- prevent sortable table to wrap
- vertical scroll issue
- in email configuration page, the vertical scroll is hidden by the logout button
- defaultGroup doesn't support null value
