### PR TITLE
Authentication againt LDAP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Qemu use *10.0.2.2* to contact host, you should replace default 'localhost' by t
 
 Once loaded, Nanocloud will be accessible on **localhost**.
 
+Authentication with LDAP:
+- ldapActivated (defaults to false) if true activates LDAP features
+- ldapUrl (defaults to 'ldap://localhost:389')
+- ldapBaseDn (defaults to empty string)
+- ldapDefaultGroup (defaults to empty string (no default group)) id of the group users should be attached to automatically
+
 # Run in developer mode
 
 Nanocloud also relies on Docker to run its development stack:

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -49,7 +49,11 @@ export default Ember.Service.extend({
     'teamEnabled',
     'machinesName',
     'neverTerminateMachine',
-    'machinePoolSize'
+    'machinePoolSize',
+    'ldapActivated',
+    'ldapUrl',
+    'ldapBaseDn',
+    'defaultGroupLdap',
   ],
   keyToBeRetrievedAsString: Ember.computed('keyToBeRetrieved', function() {
     let params = this.get('keyToBeRetrieved');

--- a/assets/app/protected/configs/ldap/controller.js
+++ b/assets/app/protected/configs/ldap/controller.js
@@ -1,0 +1,34 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+import Ember from 'ember';
+export default Ember.Controller.extend({
+  configController: Ember.inject.controller('protected.configs'),
+  defaultGroupLdap: Ember.computed.alias('configController.defaultGroupLdap'),
+  actions: {
+    selectGroup(id) {
+      this.get('configController').send('selectGroup', id);
+    },
+  }
+});

--- a/assets/app/protected/configs/ldap/template.hbs
+++ b/assets/app/protected/configs/ldap/template.hbs
@@ -1,0 +1,51 @@
+<div class="form-group row m-t-1">
+  <div class="checkbox">
+    <label>
+      {{input type="checkbox" checked=configController.ldapActivated}}
+      Activate authentication against LDAP
+    </label>
+  </div>
+</div>
+{{#if configController.ldapActivated}}
+  <div class="form-group row m-t-1">
+    <div class="col-sm-2">
+      <p class="confirm-input-item color-primary in-bl fl">LDAP URL</p>
+    </div>
+    <div class="col-sm-3">
+      {{input-confirm placeholder=configController.ldapUrl value=configController.ldapUrl type="text"}}
+    </div>
+  </div>
+  <div class="form-group row m-t-1">
+    <div class="col-sm-2">
+      <p class="confirm-input-item color-primary in-bl fl">Base DN</p>
+    </div>
+    <div class="col-sm-3">
+      {{input-confirm placeholder=configController.ldapBaseDn value=configController.ldapBaseDn type="text"}}
+    </div>
+  </div>
+  <p class='m-t-1 color-primary'>Select LDAP users default group</p>
+  <ul class="selectable-list">
+    <div class="row">
+      <div class="col-md-6">
+        <table class="table">
+          <tbody>
+            {{#each model.groups as |group|}}
+              <tr>
+                <td scope="row">
+                  <span class="link in-bl">
+                    {{#link-to 'protected.users.groups.group' group}}
+                      {{group.name}}
+                    {{/link-to}}
+                  </span>
+                </td>
+                <td {{action "selectGroup" group.id}}>
+                  {{nano-switch checked=(is-equal group.id defaultGroupLdap)}}
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </ul>
+{{/if}}

--- a/assets/app/protected/configs/template.hbs
+++ b/assets/app/protected/configs/template.hbs
@@ -16,6 +16,9 @@
       {{#link-to 'protected.configs.look-and-feel' class='nav-link'}}Look and feel{{/link-to}}
     </li>
     <li class="nav-item">
+      {{#link-to 'protected.configs.ldap' class='nav-link'}}LDAP{{/link-to}}
+    </li>
+    <li class="nav-item">
       {{#link-to 'protected.configs.other-setting' class='nav-link'}}Other settings{{/link-to}}
     </li>
   </ul>

--- a/assets/app/router.js
+++ b/assets/app/router.js
@@ -68,6 +68,7 @@ Router.map(function() {
       });
       this.route('other-setting');
       this.route('look-and-feel');
+      this.route('ldap');
     });
     this.route('brokerlog', function() {});
   });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -119,6 +119,11 @@ module.exports = {
     qemuMemory: '2048',
     qemuCPU: '2',
     qemuMachineUsername: 'Administrator',
-    qemuMachinePassword: ''
+    qemuMachinePassword: '',
+
+    ldapActivated: false,
+    ldapUrl: 'ldap://localhost:389',
+    ldapBaseDn: 'dc=nanocloud,dc=com',
+    defaultGroupLdap: ''
   }
 };

--- a/config/passport.js
+++ b/config/passport.js
@@ -111,7 +111,7 @@ passport.use(
                   return reject(null);
                 }
               });
-           });
+            });
           };
 
           ConfigService.get('ldapActivated', 'ldapUrl', 'ldapBaseDn')
@@ -165,8 +165,8 @@ passport.use(
                     }
                   }
                 });
+              });
             });
-          });
         });
     }
   ));

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "keywords": [],
   "dependencies": {
     "activedirectory": "^0.7.2",
-    "async": "^2.0.1",
     "bcryptjs": "^2.3.0",
-    "bunyan": "^1.8.1",
     "ejs": "2.3.4",
     "extend": "^3.0.0",
     "grunt": "0.4.5",
@@ -27,7 +25,6 @@
     "handlebars": "^4.0.5",
     "include-all": "~0.1.6",
     "knex": "^0.11.10",
-    "ldapjs": "^1.0.0",
     "lodash": "^4.14.0",
     "moment": "^2.13.0",
     "morgan": "^1.7.0",
@@ -49,7 +46,6 @@
     "sails-json-api-blueprints": "0.13.1",
     "sails-postgresql": "^0.11.4",
     "sha1": "^1.1.1",
-    "underscore": "^1.8.3",
     "ursa-purejs": "^0.0.3",
     "uuid": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "Nanocloud",
   "keywords": [],
   "dependencies": {
+    "activedirectory": "^0.7.2",
+    "async": "^2.0.1",
     "bcryptjs": "^2.3.0",
+    "bunyan": "^1.8.1",
     "ejs": "2.3.4",
     "extend": "^3.0.0",
     "grunt": "0.4.5",
@@ -24,6 +27,7 @@
     "handlebars": "^4.0.5",
     "include-all": "~0.1.6",
     "knex": "^0.11.10",
+    "ldapjs": "^1.0.0",
     "lodash": "^4.14.0",
     "moment": "^2.13.0",
     "morgan": "^1.7.0",
@@ -45,6 +49,7 @@
     "sails-json-api-blueprints": "0.13.1",
     "sails-postgresql": "^0.11.4",
     "sha1": "^1.1.1",
+    "underscore": "^1.8.3",
     "ursa-purejs": "^0.0.3",
     "uuid": "^2.0.2"
   },

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -22,14 +22,15 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* globals sails, AccessToken, RefreshToken, User */
+/* globals sails, AccessToken, RefreshToken, User, ConfigService */
 
 var nano = require('./lib/nanotest');
-const Promise = require('bluebird');
+const Promise = require('bluebird'),
+  activedirectory = require('activedirectory');
 
 module.exports = function() {
 
-  describe('Authentication', function() {
+  describe('Classic authentication', function() {
     describe('Login', function() {
 
       const expectedSchema = {
@@ -87,6 +88,125 @@ module.exports = function() {
           .expect(400)
           .expect(nano.schema(expectedErrorSchema))
           .end(done);
+      });
+    });
+
+    describe('Reject unauthorized', function() {
+
+      it('Should reject unauthenticated users on /api/*', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .get('/api/users')
+          .expect(401)
+          .expect({
+            error: 'access_denied',
+            error_description: 'Invalid User Credentials',
+            status: 401
+          })
+          .end(done);
+      });
+
+      it('Should allow authorized user to get his profile', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .get('/api/users')
+          .set(nano.adminLogin())
+          .expect(200)
+          .expect(nano.isJsonApi)
+          .end(done);
+      });
+    });
+  });
+
+  describe('LDAP authentication', function() {
+    describe('Login', function() {
+      const adAuthenticate = activedirectory.prototype.authenticate;
+      const adFindUser = activedirectory.prototype.findUser;
+      before(function(done) {
+        ConfigService.set('ldapActivated', true)
+          .then(() => {
+            activedirectory.prototype.authenticate = function(username, password, callback) {
+              if (username === 'jdoe@nanocloud.com' && password === 'Nanocloud123+') {
+                return callback(null, true);
+              }
+              let err = 'Wrong username or password';
+              return callback(err, false);
+            };
+            activedirectory.prototype.findUser = function(username, callback) {
+              if (username !== 'jdoe@nanocloud.com') {
+                let err = 'User ' + username + ' not found';
+                return callback(err, null);
+              }
+              let user = {
+                givenName: 'John',
+                sn: 'Doe'
+              };
+              return callback(null, user);
+            };
+            return done();
+          });
+      });
+
+      const expectedSchema = {
+        type: 'object',
+        properties: {
+          access_token: {type: 'string'},
+          refresh_token: {type: 'string'},
+          token_type: {type: 'string'},
+          expires_in: {type: 'integer'}
+        },
+        required: ['access_token', 'refresh_token', 'token_type', 'expires_in'],
+        additionalProperties: false
+      };
+
+      it('Should return token from valid username/password', function(done) {
+        nano.request(sails.hooks.http.app)
+          .post('/oauth/token')
+          .send({
+            username: 'jdoe@nanocloud.com',
+            password: 'Nanocloud123+',
+            grant_type: 'password'
+          })
+          .set('Authorization', 'Basic ' + new Buffer('9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341').toString('base64'))
+          .expect(200)
+          .expect(nano.schema(expectedSchema))
+          .expect((res) => {
+            if (res.body.token_type !== 'Bearer') {
+              throw new Error('token_type should be Bearer');
+            }
+          })
+          .end(done);
+      });
+
+      const expectedErrorSchema = {
+        type: 'object',
+        properties: {
+          error: {type: 'string'},
+          error_description: {type: 'string'}
+        },
+        required: ['error', 'error_description'],
+        additionalProperties: false
+      };
+
+      it('Should reject login with invalid username/password', function(done) {
+
+        nano.request(sails.hooks.http.app)
+          .post('/oauth/token')
+          .send({
+            username: 'jdoe',
+            password: 'Nanocloud123+',
+            grant_type: 'password'
+          })
+          .set('Authorization', 'Basic ' + new Buffer('9405fb6b0e59d2997e3c777a22d8f0e617a9f5b36b6565c7579e5be6deb8f7ae:9050d67c2be0943f2c63507052ddedb3ae34a30e39bbbbdab241c93f8b5cf341').toString('base64'))
+          .expect(400)
+          .expect(nano.schema(expectedErrorSchema))
+          .end(done);
+      });
+
+      after(function(done) {
+        activedirectory.prototype.authenticate = adAuthenticate;
+        activedirectory.prototype.findUser = adFindUser;
+        return done();
       });
     });
 

--- a/tests/api/auto-signup.test.js
+++ b/tests/api/auto-signup.test.js
@@ -111,7 +111,7 @@ module.exports = function() {
             .set(nano.adminLogin())
             .expect(200)
             .expect((res) => {
-              expect(res.body.data[1].attributes['first-name']).to.equal('Firstname');
+              expect(res.body.data[3].attributes['first-name']).to.equal('Firstname');
             });
         })
         .then(() => {
@@ -156,7 +156,7 @@ module.exports = function() {
                 .set(nano.adminLogin())
                 .expect(200)
                 .expect((res) => {
-                  let expirationDate = res.body.data[2].attributes['expiration-date'];
+                  let expirationDate = res.body.data[3].attributes['expiration-date'];
 
                   expect(moment(moment.unix(expirationDate)).diff(new Date(), 'days')).to.equal(expirationDateInConfig - 1);
                 });


### PR DESCRIPTION
This PR fixes #291.

Authenticate users against an Active Directory if classic authentication failed. This feature can be enabled/disabled in configuration page.
A new user is created in the database and can be assigned to a default group which can be set in configuration page.
