### PR TITLE
Propose to download Nanocloud VDI Experience if not installed

### DIFF
--- a/assets/app/mixins/window-manager.js
+++ b/assets/app/mixins/window-manager.js
@@ -26,6 +26,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   windowCollector: null,
+  showExtension: true,
   enabledWindow: Ember.computed('windowCollector', function() {
     let windowCollector = this.get('windowCollector');
     for (var i in windowCollector) {
@@ -72,9 +73,24 @@ export default Ember.Mixin.create({
     this.toggleProperty('windowCollector.onboardApp');
   },
 
+  checkExtension() {
+    if (navigator.userAgent.indexOf('Chrome') !== -1) {
+      window.addEventListener('message', (msg) => {
+        if (msg.data.type === 'returnCheck' && msg.data.value === 'yes') {
+          this.set('showExtension', false);
+        }
+      });
+      window.postMessage({type: 'check'}, '*');
+    } else {
+      this.set('showExtension', false);
+    }
+  },
+
   actions: {
+
     toggleWindow(item) {
       this.toggleWindow(item);
+      this.checkExtension();
     },
     closeAllWindow() {
       this.closeAllWindow();

--- a/assets/app/window/clipboard/template.hbs
+++ b/assets/app/window/clipboard/template.hbs
@@ -4,9 +4,16 @@
 
   <div class='input-wrapper'>
     <div class='textarea'>
-      {{textarea value=cloudClipboardContent }}
+      {{textarea id='VDIClipboard' value=cloudClipboardContent }}
     </div>
   </div>
+
+  {{#if showExtension}}
+    <div class='input-wrapper'>
+      <i class="clickable color-gray-dark material-icons va-sub">cloud_download</i>
+      <a class='text link' target='_blank' href='https://chrome.google.com/webstore/detail/nanocloud-vdi-experience/bdajjbbhpglhkgdobcebedgajpfdncei'>Download Nanocloud VDI Experience</a>
+    </div>
+  {{/if}}
 
   <div {{ action "savePasteToLocal" }} class='input-wrapper'>
       <i class="clickable color-gray-dark material-icons va-sub">laptop_chromebook</i>

--- a/vdiexperience/agent.js
+++ b/vdiexperience/agent.js
@@ -20,7 +20,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var executed = false;
 var port = chrome.runtime.connect();
 
 // Listen messages from nanocloud's frontend
@@ -30,16 +29,10 @@ window.addEventListener('message', function(event) {
     port.postMessage(event.data);
   } else if (event.data.type === 'onfocus') {
     port.postMessage(event.data);
+  } else if (event.data.type === 'check') {
+    window.postMessage({type: 'returnCheck', value: 'yes'}, '*');
   }
 }, false);
-
-// Send a message when user is on focus
-if (executed === false && navigator.userAgent.indexOf('Chrome') !== -1) {
-  executed = true;
-  window.onfocus = function() {
-    window.postMessage({type: 'onfocus'}, '*');
-  };
-}
 
 // Listen messages from extension's background,
 // paste data in VDI clipboard text area
@@ -55,3 +48,10 @@ port.onMessage.addListener(function(msg) {
     }
   }
 });
+
+var getUserClipboard = function() {
+  window.postMessage({type: 'onfocus'}, '*');
+};
+
+window.onfocus = getUserClipboard;
+getUserClipboard();

--- a/vdiexperience/background.js
+++ b/vdiexperience/background.js
@@ -20,41 +20,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var executed = false;
-
 // Listen when a webrequest in *://*/api/apps/* is completed
-chrome.webRequest.onCompleted.addListener(function(res) {
+chrome.webNavigation.onCompleted.addListener(function(res) {
 
-  if (executed === false) {
-    executed = true;
-    // Inject agent.js in the page
-    chrome.tabs.executeScript(res.tabId, {
-      file: 'agent.js'
-    });
+  // Inject agent.js in the page
+  chrome.tabs.executeScript(res.tabId, {
+    file: 'agent.js'
+  });
+}, {urlMatches: ['http*://*/#/vdi*']});
 
-    chrome.runtime.onConnect.addListener(function(port){
-      port.onMessage.addListener(function(msg) {
+chrome.runtime.onConnect.addListener(function(port){
+  port.onMessage.addListener(function(msg) {
 
-        // Copy from virtual machine to host
-        if (msg.type === 'VDIExperience') {
-          var textArea = document.createElement('textarea');
-          textArea.value = msg.value;
-          document.body.appendChild(textArea);
-          textArea.select();
-          document.execCommand('copy');
-          document.body.removeChild(textArea);
-        }
-        // Copy from host to virtual machine
-        else if (msg.type === 'onfocus') {
-          var paste = document.createElement('textarea');
-          document.body.appendChild(paste);
-          paste.select();
-          document.execCommand('paste');
-          port.postMessage({type: 'paste', value: paste.value});
-          document.body.removeChild(paste);
-        }
-      });
-    });
-  }
-},
-{urls: ['*://*/api/apps/*']});
+    // Copy from virtual machine to host
+    if (msg.type === 'VDIExperience') {
+      var textArea = document.createElement('textarea');
+      textArea.value = msg.value;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+    }
+    // Copy from host to virtual machine
+    else if (msg.type === 'onfocus') {
+      var paste = document.createElement('textarea');
+      document.body.appendChild(paste);
+      paste.select();
+      document.execCommand('paste');
+      port.postMessage({type: 'paste', value: paste.value});
+      document.body.removeChild(paste);
+    }
+  });
+});

--- a/vdiexperience/manifest.json
+++ b/vdiexperience/manifest.json
@@ -3,19 +3,12 @@
 
   "name": "Nanocloud VDI Experience",
   "description": "This extension offers you a better experience with Nanocloud's VDI",
-  "version": "0.1",
+  "version": "1.0",
 
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "persistent": false
   },
-
-  "content_scripts": [
-    {
-      "matches": ["*://*/#/apps"],
-      "js": ["agent.js"],
-      "all_frames": true
-    }
-  ],
 
   "icons": {
     "48": "icon48.png",
@@ -23,9 +16,9 @@
   },
 
   "permissions": [
-    "webRequest",
+    "webNavigation",
     "clipboardWrite",
     "clipboardRead",
-    "*://*/#/apps"
+    "*://*/#/vdi*"
   ]
 }


### PR DESCRIPTION
Fixes #289 
Add a link in VDI Clipboard to download Nanocloud VDI Experience if  is not installed. Only on Google Chrome.
