### PR TITLE
Fix machine may be be terminating even if a session was opened on it

### DIFF
--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -111,7 +111,7 @@ module.exports = {
       });
 
       return request.getAsync(plazaAddr)
-        .timeout(500)
+        .timeout(10000)
         .then((res) => {
           let body = res.body;
 


### PR DESCRIPTION
Increase timeout when requesting session to give machine plenty of time to respond on open sessions.
It happened the machine took time to respond (for example with qemu driver on a busy machine) leading to the user seeing his machine being terminated.
