### PR TITLE
Only one default group can be set for LDAP users.

### DIFF
--- a/assets/app/protected/configs/controller.js
+++ b/assets/app/protected/configs/controller.js
@@ -76,5 +76,12 @@ export default Ember.Controller.extend({
         this.set('defaultGroup', id);
       }
     },
+    selectGroupLdap(id) {
+      if (this.get('defaultGroupLdap') === id) {
+        this.set('defaultGroupLdap', false);
+      } else {
+        this.set('defaultGroupLdap', id);
+      }
+    },
   }
 });

--- a/assets/app/protected/configs/ldap/controller.js
+++ b/assets/app/protected/configs/ldap/controller.js
@@ -28,7 +28,7 @@ export default Ember.Controller.extend({
   defaultGroupLdap: Ember.computed.alias('configController.defaultGroupLdap'),
   actions: {
     selectGroup(id) {
-      this.get('configController').send('selectGroup', id);
+      this.get('configController').send('selectGroupLdap', id);
     },
   }
 });

--- a/assets/app/protected/configs/ldap/template.hbs
+++ b/assets/app/protected/configs/ldap/template.hbs
@@ -23,29 +23,31 @@
       {{input-confirm placeholder=configController.ldapBaseDn value=configController.ldapBaseDn type="text"}}
     </div>
   </div>
-  <p class='m-t-1 color-primary'>Select LDAP users default group</p>
-  <ul class="selectable-list">
-    <div class="row">
-      <div class="col-md-6">
-        <table class="table">
-          <tbody>
-            {{#each model.groups as |group|}}
-              <tr>
-                <td scope="row">
-                  <span class="link in-bl">
-                    {{#link-to 'protected.users.groups.group' group}}
-                      {{group.name}}
-                    {{/link-to}}
-                  </span>
-                </td>
-                <td {{action "selectGroup" group.id}}>
-                  {{nano-switch checked=(is-equal group.id defaultGroupLdap)}}
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
+  {{#if model.groups.length}}
+    <p class='m-t-1 color-primary'>Select LDAP users default group</p>
+    <ul class="selectable-list">
+      <div class="row">
+        <div class="col-md-6">
+          <table class="table">
+            <tbody>
+              {{#each model.groups as |group|}}
+                <tr>
+                  <td scope="row">
+                    <span class="link in-bl">
+                      {{#link-to 'protected.users.groups.group' group}}
+                        {{group.name}}
+                      {{/link-to}}
+                    </span>
+                  </td>
+                  <td {{action "selectGroup" group.id}}>
+                    {{nano-switch checked=(is-equal group.id defaultGroupLdap)}}
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
-  </ul>
+    </ul>
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
This PR fixes #335.

In configuration page only one group can be selected as default group for users who sign up via LDAP.
