### PR TITLE
Machine endDate is correctly check when sessionDuration is finished.

### DIFF
--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -508,20 +508,21 @@ function updateMachinesPool() {
 function _shouldTerminateMachine(machine) {
   Promise.props({
     isActive: machine.isSessionActive(),
-    config: ConfigService.get('neverTerminateMachine')
+    config: ConfigService.get('neverTerminateMachine'),
+    machineToTerminate: Machine.findOne({id: machine.id})
   })
-    .then(({isActive, config}) => {
+    .then(({isActive, config, machineToTerminate}) => {
       if (!isActive) {
         const now = new Date();
-        if (machine.endDate < now) {
+        if (machineToTerminate.endDate < now) {
           if (config.neverTerminateMachine) {
-            stopMachine(machine);
+            stopMachine(machineToTerminate);
           } else {
-            machine.user = null;
+            machineToTerminate.user = null;
 
-            Machine.update(machine.id, machine)
+            Machine.update(machineToTerminate.id, machineToTerminate)
               .then(() => {
-                _terminateMachine(machine);
+                _terminateMachine(machineToTerminate);
               });
           }
         }


### PR DESCRIPTION
When closing a vdi, we set the endDate of the machine, a timeout is starting, and _shouldTerminateMachine is called, but this function is called with the current machine, not with the machine where the end date is updated and we received the machine without the endate.
So we search the machine to know the current endate.
