### PR TITLE
Display correctly machine size on history page

### DIFF
--- a/assets/app/history/model.js
+++ b/assets/app/history/model.js
@@ -34,7 +34,7 @@ export default DS.Model.extend({
   startDate: DS.attr('date'),
   endDate: DS.attr('date'),
   machineId: DS.attr('string'),
-  machineSize: DS.attr('string'),
+  machineType: DS.attr('string'),
   machineDriver: DS.attr('string'),
   duration: Ember.computed('startDate', 'endDate', function() {
     var start = window.moment(this.get('startDate'));


### PR DESCRIPTION
Fixes #348 
Get `machineType` against `machineSize` in history model.
