### PR TITLE
Bugfix: File drag and drop does not work on file page

### DIFF
--- a/assets/app/components/vdi-drag-n-drop/component.js
+++ b/assets/app/components/vdi-drag-n-drop/component.js
@@ -30,6 +30,7 @@ var FileUploader = Ember.Object.extend(Ember.Evented, {
   progress: 0,
   uploading: false,
   forbidden: false,
+  dragAndDropActive: false,
 
   init() {
     this._super(...arguments);
@@ -191,10 +192,16 @@ export default Ember.Component.extend({
   },
 
   didInsertElement() {
-    Ember.$('body').on('dragenter dragover', (event) => {
+    Ember.$('body').on('dragenter dragover dragleave drop', (event) => {
       event.preventDefault();
 
-      this.set('show', true);
+      if (event.type === 'dragleave') {
+        return this.dragLeave();
+      }
+      else if (event.type === 'drop') { 
+        return this.drop(event);
+      }
+
       if (this.get('dragAndDropActive') === false) {
         this.set('dragAndDropActive', true);
         this.showElement();
@@ -218,6 +225,10 @@ export default Ember.Component.extend({
           input.click();
         });
     }
+  },
+
+  willDestroy() {
+    Ember.$('body').off('dragenter dragover dragleave drop');
   },
 
   completeNotif() {

--- a/assets/app/components/vdi-drag-n-drop/component.js
+++ b/assets/app/components/vdi-drag-n-drop/component.js
@@ -198,7 +198,7 @@ export default Ember.Component.extend({
       if (event.type === 'dragleave') {
         return this.dragLeave();
       }
-      else if (event.type === 'drop') { 
+      else if (event.type === 'drop') {
         return this.drop(event);
       }
 

--- a/assets/app/protected/apps/index/controller.js
+++ b/assets/app/protected/apps/index/controller.js
@@ -40,7 +40,6 @@ let App = Ember.Object.extend({
     this.set('remoteSession.plazaHasFinishedLoading', false);
     this.get('controller')
       .launchVDI(this.get('id'))
-      })
       .catch((err) => {
         if (err === 'Exceeded credit') {
           this.toast.error('Exceeded credit');

--- a/assets/app/protected/apps/index/controller.js
+++ b/assets/app/protected/apps/index/controller.js
@@ -40,6 +40,7 @@ let App = Ember.Object.extend({
     this.set('remoteSession.plazaHasFinishedLoading', false);
     this.get('controller')
       .launchVDI(this.get('id'))
+      })
       .catch((err) => {
         if (err === 'Exceeded credit') {
           this.toast.error('Exceeded credit');


### PR DESCRIPTION
dragLeave and drop hook in vdi-drag-n-drop component don't get fired when the component is called on file page.
To fix that, we call the appropriate event manually.

Fixes #353 
