### PR TITLE
Compile .NET assemblies when creating image with packer

### DIFF
--- a/packer/scripts/execute-ngen.ps1
+++ b/packer/scripts/execute-ngen.ps1
@@ -1,0 +1,4 @@
+C:\Windows\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
+C:\Windows\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
+C:\Windows\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
+C:\Windows\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems

--- a/packer/windows-2012-R2-standard-amd64.json
+++ b/packer/windows-2012-R2-standard-amd64.json
@@ -49,7 +49,8 @@
             "type": "powershell",
             "scripts": [
                 "scripts/install-plaza.ps1",
-                "scripts/install-chrome.ps1"
+                "scripts/install-chrome.ps1",
+                "scripts/execute-ngen.ps1"
             ]
         }
     ]


### PR DESCRIPTION
Windows execute some programs on first start like `.net runtime optimization service`. These programs use a lot of CPU. 
Now we execute `ngen.exe` to run all Windows needs when creating the qcow2 image. 
Machines booting on this image have no need to execute this anymore and save CPU.
