### PR TITLE
Check application's image "deleted" flag before returning it

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -53,7 +53,9 @@ module.exports = {
                  LEFT JOIN "imagegroup" on imagegroup.image = app.image
                  LEFT JOIN "group" on imagegroup.group = "group".id
                  LEFT JOIN "usergroup" on usergroup.group = "group".id
-                 WHERE usergroup.user = $1::varchar OR $2::boolean = true`,
+                 LEFT JOIN "image" on image.id = "app".image
+                 WHERE (usergroup.user = $1::varchar OR $2::boolean = true)
+                 AND image.deleted = false`,
         values: [
           user.id,
           user.isAdmin


### PR DESCRIPTION
Fixes #369 
When an image is deleted, app onboarded on this image stay in base, so we check if the app's image is deleted, before returning apps.
Step to validate:
- Go to vdi, and OnBoard an app by creating an image.
- Now their is two images and one application.
- Delete the new image.
  Expected result:
- The number of apps on dashboard should be the number of app in apps page, without desktop apps.
