### PR TITLE
Change machine's image attributes when creating an image from it.

### DIFF
--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -87,7 +87,16 @@ module.exports = {
           buildFrom: machine.id
         });
       })
-      .then(res.created)
+      .then((image) => {
+        return Machine.update({
+          id: image.buildFrom
+        }, {
+          image: image.id
+        })
+          .then(() => {
+            return res.created(image);
+          });
+      })
       .catch(res.negotiate);
   },
 

--- a/tests/api/image.test.js
+++ b/tests/api/image.test.js
@@ -86,6 +86,14 @@ module.exports = function() {
         });
     });
 
+    it('Should change machine\'s image when creating an image from it', function(done) {
+      Machine.findOne(baseMachineId)
+        .then((machine) => {
+          expect(machine.image).to.equal(anotherImageId);
+          return done();
+        });
+    });
+
     it('Should exist two images now', function(done) {
 
       nano.request(sails.hooks.http.app)


### PR DESCRIPTION
When we create an image, it take machine's id for its 'buildFrom' attribute. As this machine is the one we took to build this image, we can change machine's 'image' attribute to this new image id.
