### PR TITLE
Get on /api/groups now return members and images of all groups.

### DIFF
--- a/api/controllers/GroupController.js
+++ b/api/controllers/GroupController.js
@@ -36,5 +36,14 @@ module.exports = {
       .populate('images')
       .then(res.ok)
       .catch(res.negotiate);
+  },
+
+  find: function(req, res) {
+
+    Group.find()
+      .populate('members')
+      .populate('images')
+      .then(res.ok)
+      .catch(res.negotiate);
   }
 };


### PR DESCRIPTION
Fixes #373 

Groups request returned only the name of groups, and now return the images and members assigned on groups.
So we can count the correct number of images for a group.

Step to validate:
- Go on groups and create a group.
- Assign an image to this group.
- then go on groups page and refresh.
  Expected result:
- "number of images" for this group should correct.
