### PR TITLE
Fix toaster message.

### DIFF
--- a/assets/app/protected/apps/app/controller.js
+++ b/assets/app/protected/apps/app/controller.js
@@ -51,8 +51,8 @@ export default Ember.Controller.extend({
           this.transitionToRoute('protected.apps');
           this.toast.success('The application has been deleted');
         })
-        .catch((reason) => {
-          this.toast.error(reason.errors[0].title);
+        .catch(() => {
+          this.toast.error('The application can\'t be deleted');
         });
       }
     },

--- a/assets/app/protected/users/new/controller.js
+++ b/assets/app/protected/users/new/controller.js
@@ -52,9 +52,9 @@ export default Ember.Controller.extend({
               this.set('loadState', false);
               this.transitionToRoute('protected.users');
               this.toast.success('User has been created sucessfully');
-            }, (errorMessage) => {
+            }, () => {
               this.set('loadState', false);
-              this.toast.error('Cannot create new user : ' + errorMessage);
+              this.toast.error('Cannot create user');
             });
         });
     }

--- a/assets/app/protected/users/teams/new/controller.js
+++ b/assets/app/protected/users/teams/new/controller.js
@@ -43,7 +43,7 @@ export default Ember.Controller.extend({
           }), 0);
         })
         .catch((err) => {
-          this.toast.error(err.errors[0].detail, 'Account not created');
+          this.toast.error('Some fields you entered are invalids', 'Account not created');
           return err.responseJSON;
         })
         .finally(() => {

--- a/assets/app/protected/users/user/controller.js
+++ b/assets/app/protected/users/user/controller.js
@@ -152,8 +152,8 @@ export default Ember.Controller.extend({
         .then(({ validations }) => {
 
           if (validations.get('isInvalid') === true) {
-            this.toast.error(this.get('model.validations.attrs.firstname.messages'));
-            return defer.reject(this.get('model.validations.attrs.firstname.messages'));
+            this.toast.error(this.get('model.validations.attrs.firstName.messages'));
+            return defer.reject(this.get('model.validations.attrs.firstName.messages'));
           }
 
           this.model.save()
@@ -175,8 +175,8 @@ export default Ember.Controller.extend({
         .then(({ validations }) => {
 
           if (validations.get('isInvalid') === true) {
-            this.toast.error(this.get('model.validations.attrs.lastname.messages'));
-            return defer.reject(this.get('model.validations.attrs.lastname.messages'));
+            this.toast.error(this.get('model.validations.attrs.lastName.messages'));
+            return defer.reject(this.get('model.validations.attrs.lastName.messages'));
           }
 
           this.model.save()

--- a/assets/app/sign-up/controller.js
+++ b/assets/app/sign-up/controller.js
@@ -41,7 +41,7 @@ export default Ember.Controller.extend({
         })
         .catch((err) => {
           this.set('loadState', 0);
-          this.toast.error(err.errors[0].detail, 'Account not created');
+          this.toast.error('Some fields you entered are invalids.', 'Account not created');
           return err.responseJSON;
         });
     }


### PR DESCRIPTION
Fixes #269 

Backend error message didn't appear in toaster.
Correct variable names.

Toaster to test:
- Try to create a pending user with empty field.
- Try to update a user's information with blank data (it concerns only first name and last name fields).
- Try to fails a reset-password request. (hard to reproduce).
- When an application fail to be delete.
- When trying to create a user from a team, without valid fields.
