### PR TITLE
Assign booting machine to user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Alternativelly, tests can be run individually:
 
 Some environment variables can be set to customize tests:
 - testMail (boolean, defaults to false) load stub email transporter for testing purpose
+- dummyBootingState (boolean, defaults to false) force machine to stay in booting state for a moment
 
 **API tests expects a postgres database up and running on localhost**
 **Some tests may require storage and frontend to be up as well**

--- a/api/controllers/MachineController.js
+++ b/api/controllers/MachineController.js
@@ -118,7 +118,8 @@ module.exports = {
       .catch((err) =>  {
         if (err === 'Exceeded credit') {
           return res.send(402, err);
-        } else if (err === 'A machine is booting for you. Please retry in one minute.') {
+        } else if (err === 'A machine is booting for you. Please retry in one minute.'
+        || err === 'A machine have been assigned to you, it will be available shortly.') {
           res.notFound(err);
         } else {
           return res.negotiate(err);

--- a/api/drivers/dummy/driver.js
+++ b/api/drivers/dummy/driver.js
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* globals Machine, Image */
+/* globals Machine, Image, ConfigService */
 
 const Promise = require('bluebird');
 const uuid = require('node-uuid');
@@ -260,14 +260,24 @@ class DummyDriver extends BaseDriver {
    */
   refresh(machine) {
     return new Promise((resolve, reject) => {
-      if (machine.status === 'error') {
-        reject(machine.status);
-      } else if (machine.status === 'stopping') {
-        machine.status = 'stopped';
-        return resolve(machine);
-      }
-      machine.status = 'running';
-      return resolve(machine);
+      ConfigService.get('dummyBootingState')
+        .then((config) => {
+          if (machine.status === 'error') {
+            reject(machine.status);
+          } else if (machine.status === 'stopping') {
+            machine.status = 'stopped';
+            return resolve(machine);
+          } else if (config.dummyBootingState) {
+            setTimeout(function() {
+              machine.status = 'running';
+              return resolve(machine);
+            },
+            500);
+          } else {
+            machine.status = 'running';
+            return resolve(machine);
+          }
+        });
     });
   }
 

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -55,7 +55,6 @@ module.exports = {
     smtpLogin: '',
     smtpPassword: '',
     smtpSendFrom: 'mail@nanocloud.com',
-    testMail: false,
 
     storageAddress: 'localhost',
     storagePort: 9090,
@@ -125,6 +124,9 @@ module.exports = {
     ldapActivated: false,
     ldapUrl: 'ldap://localhost:389',
     ldapBaseDn: 'dc=nanocloud,dc=com',
-    defaultGroupLdap: ''
+    defaultGroupLdap: '',
+
+    testMail: false,
+    dummyBootingState: false
   }
 };

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -990,4 +990,52 @@ describe('Machine Service', () => {
         });
     });
   });
+
+  describe('Assign booting machine', () => {
+
+    before('Set booting', function(done) {
+      return ConfigService.set('dummyBootingState', true)
+        .then(() => {
+          return Machine.destroy({type: 'dummy'});
+        })
+        .then(() => {
+          return MachineService.updateMachinesPool();
+        })
+        .then(() => {
+          return done();
+        });
+    });
+
+    after('Unset booting', function(done) {
+      return ConfigService.set('dummyBootingState', false)
+        .then(() => {
+          return done();
+        });
+    });
+
+    it('Should assign machine to user when booting', (done) => {
+      return MachineService.getMachineForUser({
+        id: adminId
+      }, {
+        id: imageId
+      })
+        .catch((err) => {
+          if (err !== 'A machine have been assigned to you, it will be available shortly.') {
+            throw new Error('Should have a comprehensive error message');
+          }
+        })
+        .then(() => {
+          return Machine.findOne({user: adminId});
+        })
+        .then((machine) => {
+          if (machine.status !== 'booting') {
+            throw new Error('Assigned machine should have been a booting machine');
+          } else if (machine.enDate === null) {
+            throw new Error('endDate should have been set when booting machine have been assigned');
+          } else {
+            return done();
+          }
+        });
+    });
+  });
 });


### PR DESCRIPTION
fixes #302 
A booting machine can be assigned to a user. `endDate` is set for this machine accordingly to `sessionDuration`.
Add a `dummyBootingState` config variable, this force dummy driver machine to stay 0,5 second in booting state.
