### PR TITLE
Add the possibility to choose the root disk size on AWS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ MACHINES=[{"name": "My Machine", "type": "manual", "ip": "1.2.3.4", "username": 
 - awsMachineUsername (Defaults to Administrator) administrator account on the machine
 - awsMachinePassword (Defaults to empty string, will be generated if possible) administrator password on the machine
 - awsMachineSubnet (Defaults to empty string, automatic subnet) subnet to assign to the machine
+- awsDiskSize (Defaults to 0, automatic size) root disk size in GB
 - creditLimit (Defaults empty string) set a credit limit to users (aws only)
 
 ## Openstack driver specific

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -103,6 +103,7 @@ module.exports = {
     awsMachineUsername: 'Administrator',
     awsMachinePassword: '',
     awsMachineSubnet: '',
+    awsDiskSize: 0,
 
     openstackUsername:  '',
     openstackPassword: '',


### PR DESCRIPTION
Fixes #236 
Add `awsDiskSize` in config variable. By default this is an empty string, the root disk size is automatically selected by AWS.

Add option `BlockDeviceMappings`  when we create an instance to choose the root disk size.
