### PR TITLE
Fixes infinite connection status.

### DIFF
--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -114,7 +114,7 @@ module.exports = {
       });
 
       return request.getAsync(plazaAddr)
-        .timeout(10000)
+        .timeout(1000)
         .then((res) => {
           let body = res.body;
 


### PR DESCRIPTION
Fixes #342 
The connection status are available even if a machine is booting or is not reachable.
Change the plaza request timeout from 10 seconds to 1 second in `getSession`. The problem was from the `getSession` timeout, it was equal to timeout on `GET api/sessions`, so we could not get any response of `getSession` if a machine was starting up or was not reachable.
