### PR TITLE
Remove custom pkgcloud, use 1.3.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:6.3.0-slim
 MAINTAINER Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
-RUN apt-get update -y && \
-    apt-get install -y git
 RUN npm install -g pm2
 
 RUN mkdir -p /opt/back

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",
     "pg": "^6.1.0",
-    "pkgcloud": "git+https://github.com/Nanocloud/pkgcloud.git",
+    "pkgcloud": "^1.3.0",
     "promise-poller": "^1.5.0",
     "randomstring": "^1.1.5",
     "rc": "1.0.1",


### PR DESCRIPTION
We can use pkgcloud 1.3.0 instead of our custom version.
Customizations had been made, but they are no longer necessary thanks to #392 
