### PR TITLE
Set endDate of the machine to null when it is stopping.

### DIFF
--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -525,6 +525,8 @@ function _shouldTerminateMachine(machine) {
         const now = new Date();
         if (machineToTerminate.endDate < now) {
           if (config.neverTerminateMachine) {
+            machineToTerminate.endDate = null;
+
             stopMachine(machineToTerminate);
           } else {
             machineToTerminate.user = null;


### PR DESCRIPTION
Fixes #393 

In front-end, the condition record.endDate was always true, because the machine endDate was not unset.
Set it to null when the machine is  being stopped, permitted to have the record.endDate to false, and the correct message on front-end.
