### PR TITLE
Sort date column with the difference of createdAt and now.

### DIFF
--- a/assets/app/protected/brokerlog/index/controller.js
+++ b/assets/app/protected/brokerlog/index/controller.js
@@ -57,6 +57,8 @@ export default Ember.Controller.extend({
     }
     var ret = Ember.A([]);
     this.get('items').forEach(function(item) {
+      var timeNow = window.moment(new Date(),'DD/MM/YYYY HH:mm:ss');
+      var timeCreatedAt = window.moment(item.get('createdAt'),'DD/MM/YYYY HH:mm:ss');
       ret.push(Ember.Object.create({
         user: item.get('userId'),
         machineDriver: item.get('machineDriver'),
@@ -65,6 +67,7 @@ export default Ember.Controller.extend({
         state: item.get('state'),
         poolSize: item.get('poolSize'),
         createdAt: window.moment(item.get('createdAt')).format('MMMM Do YYYY, h:mm:ss A'),
+        secondsSinceCreatedAt: Math.floor(window.moment.duration(timeCreatedAt.diff(timeNow), 'milliseconds').asSeconds()),
       }));
     });
     this.set('data', ret);
@@ -113,6 +116,7 @@ export default Ember.Controller.extend({
       title: 'Created At',
       disableFiltering: true,
       filterWithSelect: false,
+      sortedBy: 'secondsSinceCreatedAt',
       sortPrecedence: true,
       sortDirection: 'desc',
     },

--- a/assets/app/protected/histories/index/controller.js
+++ b/assets/app/protected/histories/index/controller.js
@@ -68,6 +68,8 @@ export default Ember.Controller.extend({
     var sumSessionDuration = 0;
     this.get('items').forEach(function(item) {
       sumSessionDuration += item.get('duration') / 1000;
+      var timeNow = window.moment(new Date(),'DD/MM/YYYY HH:mm:ss');
+      var timeStart = window.moment(item.get('startDate'),'DD/MM/YYYY HH:mm:ss');
       ret.push(Ember.Object.create({
         user: item.get('userFullName'),
         application: item.get('connectionId'),
@@ -75,6 +77,7 @@ export default Ember.Controller.extend({
         machineId: item.get('machineId'),
         machineSize: item.get('machineType'),
         start: window.moment(item.get('startDate')).format('MMMM Do YYYY, h:mm:ss A'),
+        secondsSinceStart: Math.floor(window.moment.duration(timeStart.diff(timeNow), 'milliseconds').asSeconds()),
         end: window.moment(item.get('endDate')).format('MMMM Do YYYY, h:mm:ss A'),
         isActive: item.get('isActive'),
         duration: item.get('duration') / 1000,
@@ -123,6 +126,7 @@ export default Ember.Controller.extend({
       title: 'Start Date',
       disableFiltering: true,
       filterWithSelect: false,
+      sortedBy: 'secondsSinceStart',
     },
     {
       title: 'End Date',


### PR DESCRIPTION
Fixes #361 

Calculate, in seconds, the difference between the brokerLog/history and now,
and sort createdAt/startDate column with this difference.
