### PR TITLE
Broker wait 20 minutes before considering that the machine has a problem.

### DIFF
--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -297,13 +297,13 @@ function _createMachine(image) {
             });
         },
         interval: 5000,
-        retries: 100
+        retries: 240 // Waiting 20 minutes maximum before considering that the machine have a problem
       })
         .catch((errs) => { // If timeout is reached
 
           let machine = errs.pop(); // On timeout, promisePoller rejects with an array of all rejected promises. In our case, MachineService rejects the still booting machine. Let's pick the last one.
 
-          _createBrokerLog(machine, 'Error');
+          _createBrokerLog(machine, 'Machine take to many time to boot.');
           _terminateMachine(machine);
           throw machine;
         });
@@ -320,6 +320,9 @@ function _createMachine(image) {
         .then(() => {
           _createBrokerLog(machine, 'Available');
         });
+    })
+    .catch((errs) => {
+      return (errs);
     });
 }
 


### PR DESCRIPTION
Fixes #414 

After 20 minutes, broker consider that the machine has a booting problem, and terminate it.
