### PR TITLE
Fix not mounted team storage on Windows

### DIFF
--- a/api/controllers/HistoryController.js
+++ b/api/controllers/HistoryController.js
@@ -56,18 +56,17 @@ module.exports = {
           }, {
             id: image.id
           }),
-          app: App.findOne({id: connectionId})
+          app: App.findOne({id: connectionId}),
+          user: User.findOne({id: userId})
         });
       })
-      .then(({machine, app}) => {
+      .then(({machine, app, user}) => {
         _.set(req.body, 'data.attributes.machineId', machine.id);
         _.set(req.body, 'data.attributes.machineDriver', machine.type);
         _.set(req.body, 'data.attributes.machineType', machine.flavor);
         _.set(req.body, 'data.attributes.applicationName', app.displayName);
         if (req.body.data.attributes.endDate === '') {
-          return MachineService.sessionOpen({
-            id: machine.user
-          }, {
+          return MachineService.sessionOpen(user, {
             id: machine.image
           });
         }

--- a/tests/unit/services/MachineService.test.js
+++ b/tests/unit/services/MachineService.test.js
@@ -22,7 +22,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-/* global Image, MachineService, Machine, ConfigService, BrokerLog */
+/* global Image, MachineService, Machine, ConfigService, BrokerLog, User */
 
 const adminId = 'aff17b8b-bf91-40bf-ace6-6dfc985680bb';
 const chai = require('chai');
@@ -210,13 +210,14 @@ describe('Machine Service', () => {
     });
 
     it('Opening a session should considere it as active', (done) => {
-      Machine.findOne({
+      Promise.props({
+        machine: Machine.findOne({
         user: adminId
+        }),
+        user: User.findOne({id: adminId})
       })
-        .then((machine) => {
-          return MachineService.sessionOpen({
-            id: adminId
-          }, {
+        .then(({machine, user}) => {
+          return MachineService.sessionOpen(user, {
             id: machine.image
           });
         })
@@ -672,11 +673,12 @@ describe('Machine Service', () => {
     });
 
     it('Opening a session should considere it as active', (done) => {
-      MachineService.sessionOpen({
-        id: adminId
-      }, {
-        id: imageId
-      })
+      User.findOne({id: adminId})
+        .then((user) => {
+          return MachineService.sessionOpen(user, {
+            id: imageId
+          });
+        })
         .then(() => {
           return MachineService.getMachineForUser({
             id: adminId,


### PR DESCRIPTION
Fixes #412 
Send `user` object when we call `sessionOpen` instead of only user id.
