### PR TITLE
Change isGuacamole policie to support QA deploy

### DIFF
--- a/api/policies/isGuacamole.js
+++ b/api/policies/isGuacamole.js
@@ -30,7 +30,7 @@ module.exports = function(req, res, next) {
 
   let host = req.get('host');
 
-  if (host === 'localhost:1337' || host === 'backend:1337') {
+  if (host === 'localhost:1337' || /backend(-42[0-9]+)?:1337/.test(host)) {
     return next(null);
   }
 


### PR DESCRIPTION
When PR are deploy on QA, backend container have a name like `backend-42423`. We change isGuacamole policie to support this particularity.
