### PR TITLE
Add an error message when image failed to be create.

### DIFF
--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -444,7 +444,7 @@ class AWSDriver extends Driver {
       }, (err, image) => {
 
         if (err) {
-          return reject(err);
+          return reject(err.code);
         }
 
         Machine.findOne(imageToCreate.buildFrom)

--- a/assets/app/mixins/image.js
+++ b/assets/app/mixins/image.js
@@ -59,6 +59,18 @@ export default Ember.Mixin.create({
       }, () => {
         this.toast.success('Your image has been saved successfully');
       });
+    }, (err) => {
+      var message = ((err.responseText === '"InvalidAMIName.Duplicate"') ?
+        'This name is already used by another Ami!' : 'An unexpected error occured!');
+      window.swal({
+        title: 'An error occured',
+        text: message,
+        type: 'error',
+        showCancelButton: false,
+        confirmButtonText: 'Ok.',
+        closeOnConfirm: true,
+        animation: false
+      });
     });
 
     window.swal({


### PR DESCRIPTION
Fixes #422 

It add an error message on front when an image failed to be create.
It add a personnalized message when this error occur when an image name is already used.
