### PR TITLE
Update manual driver, for being available on 2.1.0.

### DIFF
--- a/api/drivers/manual/driver.js
+++ b/api/drivers/manual/driver.js
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global Machine, ConfigService */
+/* global Machine, ConfigService, Image */
 
 const Promise = require('bluebird');
 const Driver = require('../driver');
@@ -37,11 +37,15 @@ class ManualDriver extends Driver {
   initialize() {
     return ConfigService.set('machinePoolSize', 0)
       .then(() => {
-        return ConfigService.get('machines');
+        return Promise.props({
+          config: ConfigService.get('machines'),
+          image: Image.findOne({ name: 'Default' })
+        });
       })
-      .then((config) => {
+      .then(({config, image}) => {
 
         let machines = config.machines.map((machine) => {
+          machine.image = image.id;
           return Machine.findOrCreate(machine);
         });
 

--- a/api/models/Machine.js
+++ b/api/models/Machine.js
@@ -128,6 +128,7 @@ module.exports = {
           body.data.forEach((session) => {
             sessions.push({
               id: uuid.v4(), // id does not matter for session but is required for JSON API
+              machineId: this.id,
               username: session[1],
               state: session[3],
               userId: this.user

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -238,6 +238,17 @@ function driverName() {
 }
 
 /**
+ * Check if the driver support session duration.
+ * Manual driver don't support it.
+ *
+ * @method isSessionDurationSupported
+ * @return {Boolean}
+ */
+function isSessionDurationSupported() {
+  return driverName() !== 'manual';
+}
+
+/**
  * Set the user's machine endDate to now + `ConfigService:sessionDuration`
  *
  * @method increaseMachineEndDate
@@ -246,15 +257,19 @@ function driverName() {
  */
 function increaseMachineEndDate(machine) {
 
-  return ConfigService.get('sessionDuration')
-    .then((config) => {
-      return machine.setEndDate(config.sessionDuration)
-        .then(() => {
-          setTimeout(() => {
-            _shouldTerminateMachine(machine);
-          }, config.sessionDuration * 1000);
-        });
-    });
+  if (isSessionDurationSupported()) {
+    return ConfigService.get('sessionDuration')
+      .then((config) => {
+        return machine.setEndDate(config.sessionDuration)
+          .then(() => {
+            setTimeout(() => {
+              _shouldTerminateMachine(machine);
+            }, config.sessionDuration * 1000);
+          });
+      });
+  } else {
+    return Promise.resolve();
+  }
 }
 
 /**

--- a/assets/app/machine/model.js
+++ b/assets/app/machine/model.js
@@ -53,10 +53,4 @@ export default DS.Model.extend({
   }),
   image: DS.belongsTo('image'),
   user: DS.belongsTo('user'),
-  isStopped: Ember.computed('status', function() {
-    return (this.get('status') === 'stopping' || this.get('status') === 'stopped');
-  }),
-  isStarting: Ember.computed('status', function() {
-    return (this.get('status') === 'starting');
-  }),
 });

--- a/assets/app/protected/machines/index/controller.js
+++ b/assets/app/protected/machines/index/controller.js
@@ -63,6 +63,7 @@ export default Ember.Controller.extend({
           }
           ret.push(Ember.Object.create({
             name: item.get('machineName'),
+            image: item.get('image'),
             id: item.get('id'),
             ip: item.get('ip'),
             expiration: secondsLeft,

--- a/assets/app/protected/machines/index/controller.js
+++ b/assets/app/protected/machines/index/controller.js
@@ -51,30 +51,32 @@ export default Ember.Controller.extend({
   setData: function() {
     var ret = Ember.A([]);
     var neverTerminateMachine = this.get('configController.neverTerminateMachine');
-    this.get('items').forEach(function(item) {
-      let now = new Date();
-      let endDate = window.moment(item.get('endDate'));
-      let secondsLeft = Math.floor(window.moment.duration(window.moment(endDate,'DD/MM/YYYY HH:mm:ss').diff(window.moment(now,'DD/MM/YYYY HH:mm:ss')), 'milliseconds').asSeconds());
+    this.get('store').query('session', {})
+      .then((sessions) => {
+        this.get('items').forEach(function(item) {
+          let now = new Date();
+          let endDate = window.moment(item.get('endDate'));
+          let secondsLeft = Math.floor(window.moment.duration(window.moment(endDate,'DD/MM/YYYY HH:mm:ss').diff(window.moment(now,'DD/MM/YYYY HH:mm:ss')), 'milliseconds').asSeconds());
 
-      if (secondsLeft < 0) {
-        secondsLeft = 0;
-      }
-      ret.push(Ember.Object.create({
-        name: item.get('machineName'),
-        image: item.get('image'),
-        id: item.get('id'),
-        ip: item.get('ip'),
-        expiration: secondsLeft,
-        status: item.get('status'),
-        user: item.get('user'),
-        endDate: item.get('endDate'),
-        stopped: item.get('isStopped'),
-        starting: item.get('isStarting'),
-        neverTerminateMachine: neverTerminateMachine,
-      }));
-    });
-    this.set('data', ret);
-    return ret;
+          if (secondsLeft < 0) {
+            secondsLeft = 0;
+          }
+          ret.push(Ember.Object.create({
+            name: item.get('machineName'),
+            id: item.get('id'),
+            ip: item.get('ip'),
+            expiration: secondsLeft,
+            status: item.get('status'),
+            user: item.get('user'),
+            endDate: item.get('endDate'),
+            // Here we check if a session(s) is open on this machine.
+            isInUse: ((sessions.filterBy('machineId', item.get('id')).length === 0) ? false : true),
+            neverTerminateMachine: neverTerminateMachine,
+          }));
+        });
+        this.set('data', ret);
+        return ret;
+      });
   },
 
   columns: [

--- a/assets/app/protected/machines/index/table/machine-list/expiration/template.hbs
+++ b/assets/app/protected/machines/index/table/machine-list/expiration/template.hbs
@@ -1,4 +1,6 @@
-{{#if record.endDate}}
+{{#if record.isInUse}}
+  <span class='color-success'>Currently in use</span>
+{{else if record.endDate}}
   {{#if record.expiration}}
     {{live-countdown class='color-primary' value=record.expiration isTime=true}}
   {{else}}
@@ -7,14 +9,6 @@
     {{else}}
       This machine will be terminated soon.
     {{/if}}
-  {{/if}}
-{{else if record.user}}
-  {{#if record.stopped}}
-    -
-  {{else if record.starting}}
-    -
-  {{else}}
-    <span class='color-success'>Currently in use</span>
   {{/if}}
 {{else}}
   -

--- a/assets/app/session/model.js
+++ b/assets/app/session/model.js
@@ -28,6 +28,7 @@ import DS from 'ember-data';
 export default Model.extend({
 
   Id: DS.attr('string'),
+  machineId: DS.attr('string'),
   sessionName: DS.attr('string'),
   username: DS.attr('string'),
   state: DS.attr('string'),

--- a/tests/api/session.test.js
+++ b/tests/api/session.test.js
@@ -36,7 +36,8 @@ module.exports = function() {
       properties: {
         'username': {type: 'string'},
         'state': {type: 'string'},
-        'user-id': {type: ['string', 'null']}
+        'user-id': {type: ['string', 'null']},
+        'machine-id': {type: ['string', 'null']}
       },
       required: ['username', 'state'],
       additionalProperties: false


### PR DESCRIPTION
Fixes #262 

Add the default image on all machines specified for manual driver.
It refactor front machine page, to correctly check if a machine is "in use" in the same way for all drivers:
- A request is send on sessions, for know if the machine is in use.
  Session know include the machine id of the sessions opened.
