### PR TITLE
Correctly check machine's image when updating history

### DIFF
--- a/api/controllers/HistoryController.js
+++ b/api/controllers/HistoryController.js
@@ -25,7 +25,7 @@
  * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
 
-/* global App, User, MachineService, Image, JsonApiService */
+/* global App, User, MachineService, Image, JsonApiService, History, Machine */
 
 const _= require('lodash');
 const Promise = require('bluebird');
@@ -86,6 +86,7 @@ module.exports = {
   update(req, res) {
 
     req.body = JsonApiService.deserialize(req.body);
+    var historyId = req.allParams().id;
 
     let userId = _.get(req.body, 'data.attributes.userId');
     let connectionId = _.get(req.body, 'data.attributes.connectionId');
@@ -101,24 +102,23 @@ module.exports = {
           throw new Error('Connection not found');
         }
 
+        return History.findOne({
+          id: historyId
+        });
+      })
+      .then((history) => {
+
         return Promise.props({
-          image: Image.findOne(app.image),
+          machine: Machine.findOne({ id: history.machineId }),
           user: User.findOne(userId)
         });
       })
-      .then(({image, user}) => {
-        return MachineService.sessionEnded(user, image)
+      .then(({machine, user}) => {
+        return MachineService.sessionEnded(user, { id: machine.image })
           .then(() => {
-            return MachineService.getMachineForUser({
-              id: userId
-            }, {
-              id: image.id
-            });
+            _.set(req.body, 'data.attributes.machineId', machine.id);
+            return JsonApiService.updateOneRecord(req, res);
           });
-      })
-      .then((machine) => {
-        _.set(req.body, 'data.attributes.machineId', machine.id);
-        return JsonApiService.updateOneRecord(req, res);
       })
       .catch((err) => {
         if (err.message === 'Connection not found') {


### PR DESCRIPTION
Fixe #429 
Step use to get the correct image when updating history:
- Get history id to update
- Get machine id on this history
- Then, we have the machine with the correct image, so we continue but using this image.

Previously, the image was find by application id, causing trouble when calling getMachineForUser, who assigned a new machine to the user. see #429 
