### PR TITLE
Show the assigned user to the machine, when going on machine details.

### DIFF
--- a/assets/app/protected/machines/machine/template.hbs
+++ b/assets/app/protected/machines/machine/template.hbs
@@ -54,7 +54,7 @@
           <th scope="row">Assigned user</th>
           <td>
             {{#if model.user}}
-              {{#link-to 'protected.users.user' user.id}}
+              {{#link-to 'protected.users.user' model.user.id}}
                 {{ model.user.fullName }}
               {{/link-to}}
             {{else}}

--- a/assets/app/protected/machines/machine/template.hbs
+++ b/assets/app/protected/machines/machine/template.hbs
@@ -53,9 +53,9 @@
         <tr>
           <th scope="row">Assigned user</th>
           <td>
-            {{#if user}}
+            {{#if model.user}}
               {{#link-to 'protected.users.user' user.id}}
-                {{ user.fullName }}
+                {{ model.user.fullName }}
               {{/link-to}}
             {{else}}
               None


### PR DESCRIPTION
Go on machine details of a machine with a user assigned to it.
The assigned user should be the same on machine's detail, but actually, it's "None".
Change user to model.user, cause user is defined in model.
