### PR TITLE
Add comprehensive message when an image name is not correct for AWS

### DIFF
--- a/assets/app/mixins/image.js
+++ b/assets/app/mixins/image.js
@@ -60,8 +60,12 @@ export default Ember.Mixin.create({
         this.toast.success('Your image has been saved successfully');
       });
     }, (err) => {
-      var message = ((err.responseText === '"InvalidAMIName.Duplicate"') ?
-        'This name is already used by another Ami!' : 'An unexpected error occured!');
+      var message = 'An unexpected error occured!';
+      if (err.responseText === '"InvalidAMIName.Duplicate"') {
+        message = 'This name is already used by another Ami!';
+      } else if (err.responseText === '"InvalidAMIName.Malformed"') {
+        message = 'Wrong name, must be between 3 and 128 characters long and may contain only letters, numbers, and these following characters: ( ) . - / _';
+      }
       window.swal({
         title: 'An error occured',
         text: message,


### PR DESCRIPTION
"_AMI names must be between 3 and 128 characters long, and may contain letters, numbers, and only the following characters: ( ) . - / __" - AWS

Add a comprehensive message when trying to create an image without these specifications.
