### PR TITLE
Add the possibility to add apps on groups.

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -24,7 +24,8 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 
-/* globals App, UserGroup, Image, ImageGroup, Machine, MachineService, JsonApiService, PlazaService, ConfigService */
+/* globals App, UserGroup, Image, ImageGroup, Machine, MachineService */
+/* globals JsonApiService, PlazaService, ConfigService, AppGroup */
 
 /**
  * Controller of apps resource.
@@ -252,5 +253,17 @@ module.exports = {
           return res.negotiate(err);
         }
       });
+  },
+  destroy(req, res) {
+    var appId = req.allParams().id;
+
+    return AppGroup.destroy({ app: appId })
+      .then(() => {
+        return App.destroy({ id: appId });
+      })
+      .then(() => {
+        return res.ok();
+      })
+      .catch(res.negotiate);
   }
 };

--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -92,6 +92,7 @@ module.exports = {
         id: req.allParams().id
       })
         .populate('image')
+        .populate('groups')
         .then(res.ok);
     } else {
       this._getApps(req.user)
@@ -114,6 +115,7 @@ module.exports = {
 
         App.find(appIds)
           .populate('image')
+          .populate('groups')
           .then((apps) => {
             return res.ok(apps);
           });

--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -263,9 +263,7 @@ module.exports = {
       .then(() => {
         return App.destroy({ id: appId });
       })
-      .then(() => {
-        return res.ok();
-      })
+      .then(res.ok)
       .catch(res.negotiate);
   }
 };

--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -164,6 +164,9 @@ module.exports = {
                 req.user.isAdmin
               ]
             }, (err, groupApps) => {
+              if (err) {
+                return res.negotiate(err);
+              }
               groupApps = groupApps.rows;
               _.map(images, (image) => {
                 _.remove(image.apps, (app) => {

--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -187,7 +187,7 @@ module.exports = {
 
   destroy: function(req, res) {
     var imageId = req.allParams().id;
-    return Image.findOne({ id: req.allParams().id })
+    return Image.findOne({ id: imageId })
       .then((image) => {
         return MachineService.deleteImage(image);
       })

--- a/api/migrations/030_add_appgroup_table.js
+++ b/api/migrations/030_add_appgroup_table.js
@@ -50,9 +50,9 @@ function up(knex, Promise) {
                   }).into('appgroup');
                 });
               });
-          });
-      });
-     }),
+            });
+        });
+      }),
   ]);
 }
 

--- a/api/migrations/030_add_appgroup_table.js
+++ b/api/migrations/030_add_appgroup_table.js
@@ -16,36 +16,26 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * GroupController
- *
- * @description :: Server-side logic for managing groups
- * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
  */
 
-/* global Group */
+function up(knex) {
+  return knex.schema.createTable('appgroup', (table) => {
+    table.increments();
 
-module.exports = {
+    table.string('group');
+    table.string('app');
 
-  findOne: function(req, res) {
+    table.dateTime('createdAt');
+    table.dateTime('updatedAt');
+  });
+}
 
-    Group.findOne(req.allParams().id)
-      .populate('members')
-      .populate('images')
-      .populate('apps')
-      .then(res.ok)
-      .catch(res.negotiate);
-  },
+function down(knex) {
+  return knex.schema.dropTable('appgroup');
+}
 
-  find: function(req, res) {
-
-    Group.find()
-      .populate('members')
-      .populate('images')
-      .populate('apps')
-      .then(res.ok)
-      .catch(res.negotiate);
-  }
-};
+module.exports = { up, down };

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -57,6 +57,11 @@ module.exports = {
     },
     image: {
       model: 'image',
+    },
+    groups: {
+      collection: 'group',
+      via: 'apps',
+      through: 'appgroup'
     }
   }
 };

--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -53,6 +53,11 @@ module.exports = {
       collection: 'image',
       via: 'groups',
       through: 'imagegroup'
+    },
+    apps: {
+      collection: 'app',
+      via: 'groups',
+      through: 'appgroup'
     }
   },
 

--- a/assets/app/group/model.js
+++ b/assets/app/group/model.js
@@ -29,4 +29,5 @@ export default DS.Model.extend({
 
   members: DS.hasMany('user'),
   images: DS.hasMany(),
+  apps: DS.hasMany(),
 });

--- a/assets/app/protected/users/groups/group/images/controller.js
+++ b/assets/app/protected/users/groups/group/images/controller.js
@@ -35,7 +35,11 @@ export default Ember.Controller.extend({
   actions: {
     addImage(image) {
       let group = this.get('group');
+      let imageApps = image.get('apps').toArray();
 
+      imageApps.forEach((imageApp) => {
+        group.get('apps').pushObject(imageApp);
+      });
       group.get('images').pushObject(image);
       group.save();
     },
@@ -43,7 +47,11 @@ export default Ember.Controller.extend({
     removeImage(image) {
       let group = this.get('group');
       let images = group.get('images');
+      let imageApps = image.get('apps').toArray();
 
+      imageApps.forEach((imageApp) => {
+        group.get('apps').removeObject(imageApp);
+      });
       images.removeObject(image);
       group.save();
     },

--- a/assets/app/protected/users/groups/group/images/controller.js
+++ b/assets/app/protected/users/groups/group/images/controller.js
@@ -28,6 +28,9 @@ import ArrayDiff from 'nanocloud/lib/array-diff';
 export default Ember.Controller.extend({
   groupController: Ember.inject.controller('protected.users.groups.group'),
   groupBinding: 'groupController.model',
+  selectedImageLength: Ember.computed('group.images', function() {
+    return this.get('group.images').toArray().length;
+  }),
 
   actions: {
     addImage(image) {
@@ -42,6 +45,21 @@ export default Ember.Controller.extend({
       let images = group.get('images');
 
       images.removeObject(image);
+      group.save();
+    },
+
+    addApp(app) {
+      let group = this.get('group');
+
+      group.get('apps').pushObject(app);
+      group.save();
+    },
+
+    removeApp(app) {
+      let group = this.get('group');
+      let apps = group.get('apps');
+
+      apps.removeObject(app);
       group.save();
     }
   },

--- a/assets/app/protected/users/groups/group/images/template.hbs
+++ b/assets/app/protected/users/groups/group/images/template.hbs
@@ -9,6 +9,7 @@
           {{#if selectedImageLength}}
             <th>App</th>
             <th></th>
+            <th></th>
           {{/if}}
         </tr>
       </thead>
@@ -42,6 +43,14 @@
                 </tr>
               {{/each}}
               </td>
+                <td>
+                  <tr>
+                    <i class="material-icons color-wait">warning</i>
+                  </tr>
+                  <tr>
+                    Deselecting applications does not forbid users to access them through Windows.
+                  </tr>
+                </td>
             {{/if}}
           </tr>
         {{/each}}

--- a/assets/app/protected/users/groups/group/images/template.hbs
+++ b/assets/app/protected/users/groups/group/images/template.hbs
@@ -4,8 +4,12 @@
     <table class="table m-t-2">
       <thead>
         <tr>
-          <th>Name</th>
+          <th>Image</th>
           <th></th>
+          {{#if selectedImageLength}}
+            <th>App</th>
+            <th></th>
+          {{/if}}
         </tr>
       </thead>
       <tbody>
@@ -21,6 +25,24 @@
             <td>
               {{toggle-item-from-list list=group.images item=image property='id' addAction="addImage" removeAction="removeImage"}}
             </td>
+            {{#if (filterArrayByProperty group.images image 'id')}}
+              <td>
+              {{#each image.apps as |app|}}
+                <tr>
+                <td scope="row">
+                  <span class="link in-bl">
+                    {{#link-to 'protected.images.app' app}}
+                      {{app.displayName}}
+                    {{/link-to}}
+                  </span>
+                </td>
+                <td>
+                  {{toggle-item-from-list list=group.apps item=app property='id' addAction="addApp" removeAction="removeApp"}}
+                </td>
+                </tr>
+              {{/each}}
+              </td>
+            {{/if}}
           </tr>
         {{/each}}
 

--- a/assets/app/protected/users/groups/index/controller.js
+++ b/assets/app/protected/users/groups/index/controller.js
@@ -61,6 +61,7 @@ export default Ember.Controller.extend({
         name: item.get('name'),
         members: item.get('members.length'),
         images: item.get('images.length'),
+        apps: item.get('apps.length'),
       }));
     });
     this.set('data', ret);
@@ -84,6 +85,12 @@ export default Ember.Controller.extend({
     {
       propertyName: 'images',
       title: 'Number of images',
+      disableFiltering: true,
+      filterWithSelect: false
+    },
+    {
+      propertyName: 'apps',
+      title: 'Number of applications',
       disableFiltering: true,
       filterWithSelect: false
     },

--- a/tests/api/apps.test.js
+++ b/tests/api/apps.test.js
@@ -196,7 +196,7 @@ module.exports = function() {
        * - 3 users (admin, someguy and someotherguy)
        * - 2 apps (app1 and app2 which is the desktop)
        * image has app1 and desktop has apps
-       * group1 has admin and someotherguy as users and image as image
+       * group1 has admin and someotherguy as users and image as image and app1 as app
        * group2 has someguy and someotherguy as users and no link to any image
        */
       before('Add proper groups, users and app for testing', function(done) {
@@ -305,6 +305,12 @@ module.exports = function() {
                       }, {
                         'type': 'users',
                         'id': nano.adminId()
+                      }]
+                    },
+                    'apps': {
+                      'data': [{
+                        'type': 'apps',
+                        'id': app1
                       }]
                     }
                   },
@@ -415,7 +421,7 @@ module.exports = function() {
                   }
                 });
 
-                expect(res.body.data).to.include({
+                expect(res.body.data).to.not.include({
                   'type': 'apps',
                   'id': app2,
                   'attributes': {
@@ -432,6 +438,12 @@ module.exports = function() {
                         'type': 'images',
                         'id': image
                       }
+                    },
+                    'groups': {
+                      'data': [{
+                        'type': 'groups',
+                        'id': group1
+                      }]
                     }
                   }
                 });
@@ -452,6 +464,12 @@ module.exports = function() {
                         'type': 'images',
                         'id': image
                       }
+                    },
+                    'groups': {
+                      'data': [{
+                        'type': 'groups',
+                        'id': group1
+                      }]
                     }
                   }
                 });


### PR DESCRIPTION
Fixes #420 
When an image is added to a group, image's apps can be selected/deselected to be associated on the group.
Update the detroys function of image and app controllers:
 - Now when deleting an image, all associations (apps, image group, app group) are deleted too.
 - Now when deleting an app, all associations (app group) are deleted.