### PR TITLE
Machine are available in machine page, for regular users.

### DIFF
--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -30,8 +30,15 @@ const _ = require('lodash');
 module.exports = {
 
   find: function(req, res) {
+    let promise = null;
 
-    Machine.find()
+    if (req.user.isAdmin) {
+      promise = Machine.find();
+    } else {
+      promise = Machine.find({ user: req.user.id });
+    }
+
+    promise
       .then((machines) => {
 
         let sessionsRequest = [];

--- a/config/policies.js
+++ b/config/policies.js
@@ -61,10 +61,6 @@ module.exports.policies = {
     create: 'isAdmin'
   },
 
-  SessionController: {
-    find: 'isAdmin'
-  },
-
   GroupController: {
     create: 'isAdmin',
     find: 'isAdmin',

--- a/tests/api/security.test.js
+++ b/tests/api/security.test.js
@@ -2762,11 +2762,11 @@ module.exports = function() {
             .end(done);
         });
 
-        it('Regular users should be unauthorized', function(done) {
+        it('Regular users should be authorized', function(done) {
           nano.request(sails.hooks.http.app)
             .get('/api/sessions')
             .set('Authorization', 'Bearer ' + token)
-            .expect(403)
+            .expect(200)
             .end(done);
         });
 


### PR DESCRIPTION
Fixes #460 

When going to machines page, a request is made to sessions to know if machines are in use.
Regular users didn't have the right to request this endpoint.
Correct it by let regular users access only his sessions informations, checking his right before returning sessions.