### PR TITLE
Delete ami on iaas when deleting it on nanocloud.

### DIFF
--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -138,11 +138,17 @@ module.exports = {
   },
 
   destroy: function(req, res) {
-    return Image.update({
-      id: req.allParams().id
-    }, {
-      deleted: true
-    })
+    return Image.findOne({ id: req.allParams().id })
+      .then((image) => {
+        return MachineService.deleteImage(image);
+      })
+      .then((imageDeleted) => {
+        return Image.update({
+          id: imageDeleted.id
+        }, {
+          deleted: true
+        });
+      })
       .then((image) => {
         return MachineService.updateMachinesPool()
           .then(() => {

--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -481,6 +481,32 @@ class AWSDriver extends Driver {
   }
 
   /**
+   * Delete the specified image
+   *
+   * @method deleteImage
+   * @param {image} image Image to delete
+   * @return {Promise[Image]} resolves to the deleted image
+   */
+  deleteImage(imageToDelete) {
+    return new Promise((resolve, reject) => {
+      return ConfigService.get('awsImage')
+        .then((config) => {
+          if (config.awsImage === imageToDelete.iaasId) {
+            return reject('Default image can\'t be delete');
+          }
+          this._client.ec2.deregisterImage({
+            ImageId: imageToDelete.iaasId
+          }, (err) => {
+            if (err) {
+              return reject(err);
+            }
+            return resolve(imageToDelete);
+          });
+        });
+    });
+  }
+
+  /**
    * Calculate credit used by a user
    *
    * @method getUserCredit

--- a/api/drivers/driver.js
+++ b/api/drivers/driver.js
@@ -110,6 +110,17 @@ class Driver {
     return Promise.reject(new Error('Driver\'s method "createImage" not implemented'));
   }
 
+  /*
+   * Delete an image
+   *
+   * @method deleteImage
+   * @param {Object} Image object
+   * @return {Promise[Image]} resolves to the deleted image
+   */
+  deleteImage(/* image */) {
+    return Promise.reject(new Error('Driver\'s method "deleteImage" not implemented'));
+  }
+
   /**
    * Calculate credit used by a user
    *

--- a/api/drivers/qemu/driver.js
+++ b/api/drivers/qemu/driver.js
@@ -240,6 +240,38 @@ class QemuDriver extends Driver {
   }
 
   /**
+   * Delete the specified image
+   *
+   * @method deleteImage
+   * @param {image} image Image to delete
+   * @return {Promise[Image]} resolves to the deleted image
+   */
+  deleteImage(imageToDelete) {
+    return new Promise((resolve, reject) => {
+      if (imageToDelete.iaasId === 'image.qcow2') {
+        return reject('Default image can\'t be delete');
+      }
+      return ConfigService.get('qemuServiceURL', 'qemuServicePort')
+        .then((config) => {
+          return request({
+            url: 'http://' + config.qemuServiceURL + ':' + config.qemuServicePort + '/images',
+            json: true,
+            method: 'DELETE',
+            body: {
+              iaasId: imageToDelete.iaasId
+            }
+          });
+        })
+        .then(() => {
+          return resolve(imageToDelete);
+        })
+        .catch((err) => {
+          return reject(err);
+        });
+    });
+  }
+
+  /**
    * Retrieve the machine's data
    *
    * @method refresh

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -859,6 +859,20 @@ function createImage(image) {
 }
 
 /*
+ * Delete an image
+ *
+ * @method deleteImage
+ * @param {Object} Image object
+ * @return {Promise[Image]} resolves to the deleted image
+ */
+function deleteImage(image) {
+  return _driver.deleteImage(image)
+    .catch((err) => {
+      return Promise.reject(err);
+    });
+}
+
+/*
  * Create a new broker log
  *
  * @method _createBrokerLog
@@ -965,5 +979,5 @@ function rebootMachine(machine) {
 module.exports = {
   initialize, getMachineForUser, driverName, sessionOpen, sessionEnded,
   machines, createImage, refresh, getPassword, rebootMachine, startMachine,
-  stopMachine, updateMachinesPool
+  stopMachine, updateMachinesPool, deleteImage
 };

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -868,6 +868,13 @@ function createImage(image) {
 function deleteImage(image) {
   return _driver.deleteImage(image)
     .catch((err) => {
+      /**
+       * If the method is not implemented on the driver, it's not an
+       * error du to the driver, so we ignore this error silently
+       */
+      if (err.message === 'Driver\'s method "deleteImage" not implemented') {
+        return Promise.resolve(image);
+      }
       return Promise.reject(err);
     });
 }

--- a/qemu/index.js
+++ b/qemu/index.js
@@ -290,6 +290,14 @@ app.post('/images', upload.array(), function (req, res) {
     });
 });
 
+app.delete('/images', function(req, res) {
+  var imageToDelete = req.body.iaasId;
+  var cmd = `rm -f ${drivePath}${imageToDelete}`;
+
+  exec(cmd, () => {});
+  res.status = 200;
+  return res.send({iaasId: imageToDelete});
+});
 
 app.get('/', function (req, res) {
   return res.send('Qemu manager');


### PR DESCRIPTION
Fixes #431

On aws and qemu, delete an image now delete the image on the iaas too.
Add an endpoint to delete an image, on Qemu manager.

Step to test for aws:
 - Go to the vdi and create an image with a name you will remember.
 - Disconnect, and delete this image.
 - Go again to your vdi and create an image with the same name of the last image you create.

Expected result: no error occured, and the image is correctly created.
