### PR TITLE
Change Windows hostname on each machine

### DIFF
--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -826,8 +826,28 @@ function createImage(image) {
 
   return Machine.findOne(image.buildFrom)
     .then((machine) => {
-      return Image.findOne(machine.image)
-        .populate('apps');
+
+      return PlazaService.exec(machine.ip, machine.plazaport, {
+        command: [
+          `reg.exe`,
+          `add`,
+          `HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce`,
+          `/v`,
+          `ChangeComputerName`,
+          `/t`,
+          `REG_SZ`,
+          `/d`,
+          `"C:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\powershell.exe -command ' & C:\\Windows\\changeComputerName.ps1'"`,
+          `/f`
+        ],
+        wait: true,
+        hideWindow: true,
+        username: machine.username
+      })
+        .then(() => {
+          return Image.findOne(machine.image)
+            .populate('apps');
+        });
     })
     .then((oldImage) => {
       return _driver.createImage(image)

--- a/image/changeComputerName.ps1
+++ b/image/changeComputerName.ps1
@@ -1,0 +1,26 @@
+# Set allowed ASCII character codes to Uppercase letters (65..90),
+$charcodes = 65..90
+
+# Convert allowed character codes to characters
+$allowedChars = $charcodes | ForEach-Object { [char][byte]$_ }
+
+$LengthOfName = 10
+# Generate computer name
+$pw = ($allowedChars | Get-Random -Count $LengthOfName) -join ""
+$prefix = "CDW12"
+$name = $prefix+$pw
+
+$ComputerName = $name
+
+Remove-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname"
+Remove-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "NV Hostname"
+
+New-PSDrive -name HKU -PSProvider "Registry" -Root "HKEY_USERS"
+
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\Computername\Computername" -name "Computername" -value $ComputerName
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\Computername\ActiveComputername" -name "Computername" -value $ComputerName
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname" -value $ComputerName
+Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "NV Hostname" -value $ComputerName
+Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "AltDefaultDomainName" -value $ComputerName
+Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "DefaultDomainName" -value $ComputerName
+#Set-ItemProperty -path "HKU:.Default\Software\Microsoft\Windows Media\WMSDK\General" -name "Computername" -value $ComputerName

--- a/image/changeComputerName.ps1
+++ b/image/changeComputerName.ps1
@@ -1,3 +1,5 @@
+# This script was originally found here: http://stackoverflow.com/questions/21679369/runonce-to-rename-a-computername-with-a-random-name-on-reboot & https://gist.github.com/timnew/2373475
+
 # Set allowed ASCII character codes to Uppercase letters (65..90),
 $charcodes = 65..90
 
@@ -5,6 +7,7 @@ $charcodes = 65..90
 $allowedChars = $charcodes | ForEach-Object { [char][byte]$_ }
 
 $LengthOfName = 10
+
 # Generate computer name
 $pw = ($allowedChars | Get-Random -Count $LengthOfName) -join ""
 $prefix = "CDW12"
@@ -23,4 +26,3 @@ Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
 Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "NV Hostname" -value $ComputerName
 Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "AltDefaultDomainName" -value $ComputerName
 Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "DefaultDomainName" -value $ComputerName
-#Set-ItemProperty -path "HKU:.Default\Software\Microsoft\Windows Media\WMSDK\General" -name "Computername" -value $ComputerName


### PR DESCRIPTION
Fixes #467 #451 

To have a unique hostname on each machine we have to add a script in the AMI and create a registry key before create an image. This registry key has the effect to run the script on start. 