### PR TITLE
Doesn't show team of users if the option is disabled.

### DIFF
--- a/assets/app/protected/users/index/controller.js
+++ b/assets/app/protected/users/index/controller.js
@@ -25,6 +25,7 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  configController: Ember.inject.controller('protected.configs'),
 
   store: Ember.inject.service('store'),
   activator: function() {

--- a/assets/app/protected/users/index/table/user-list/team-setting/template.hbs
+++ b/assets/app/protected/users/index/table/user-list/team-setting/template.hbs
@@ -1,24 +1,28 @@
-{{#if record.team.name}}
-  {{record.team.name}}
-{{else}}
-  -
-{{/if}}
-{{#if targetObject.teams.length}}
-  <div class='rel in-bl fright' {{ action toggleUserSetting record }}>
+{{#if targetObject.configController.teamEnabled}}
+  {{#if record.team.name}}
+    {{record.team.name}}
+  {{else}}
+    -
+  {{/if}}
+  {{#if targetObject.teams.length}}
+    <div class='rel in-bl fright' {{ action toggleUserSetting record }}>
       {{icon-component class='va-sub color-primary clickable color-default' hover-darker=true materialIcon='settings' size=16}}
       {{#if record.teamOptionIsOpen}}
         {{#popup-component isOpen=record.teamOptionIsOpen close=closePopup position="left"}}
-        <div class="list-group">
-          <a href="#" class="list-group-item list-group-item-action unclickable active"><span class='va-tb'>Teams</span></a>
-          {{#each targetObject.teams as |team|}}
-          <a href="#" class="list-group-item list-group-item-action" {{ action changeUserTeam record team }} >{{team.name}}
-            {{#if (is-equal team.id record.team.id)}}
-            {{icon-component materialIcon='done' class='color-primary in-bl va-sub fright' size=16}}
-            {{/if}}
-          </a>
-          {{/each}}
-        </div>
+          <div class="list-group">
+            <a href="#" class="list-group-item list-group-item-action unclickable active"><span class='va-tb'>Teams</span></a>
+            {{#each targetObject.teams as |team|}}
+              <a href="#" class="list-group-item list-group-item-action" {{ action changeUserTeam record team }} >{{team.name}}
+                {{#if (is-equal team.id record.team.id)}}
+                  {{icon-component materialIcon='done' class='color-primary in-bl va-sub fright' size=16}}
+                {{/if}}
+              </a>
+              {{/each}}
+          </div>
         {{/popup-component}}
       {{/if}}
-  </div>
+    </div>
+  {{/if}}
+{{else}}
+  -
 {{/if}}


### PR DESCRIPTION
Fixes #468 

When going to users page, we now check if the team option is enable before display user's team.

Step to validate:
 - Enable teams.
 - Create a team.
 - Disable teams.
 - Go to users page.

Expected result: no team is displayed for users who has one.