### PR TITLE
Add clipboard integration for Photon.

### DIFF
--- a/assets/app/utils/photon.js
+++ b/assets/app/utils/photon.js
@@ -24,6 +24,24 @@
 
 /* globals RTCPeerConnection, RTCSessionDescription */
 
+let ClipboardManager  = function(get, set, rtcChannel) {
+  let element = document.getElementById('VDIClipboard');
+  this._element = get;
+  this._rtcChannel = rtcChannel;
+
+  var getevent = function(event) {
+    event.preventDefault();
+    rtcChannel.send('G');
+  };
+  var setevent = function(event) {
+    event.preventDefault();
+    rtcChannel.send('S' + element.value);
+  };
+
+  get.addEventListener('click', getevent);
+  set.addEventListener('change', setevent);
+};
+
 let KeyboardManager  = function(element, rtcChannel) {
   this._element = element;
   this._rtcChannel = rtcChannel;
@@ -109,6 +127,10 @@ var PeerConnectionManager = function(videoElement, serverAddress, access_token) 
   this._dataChannel = dataChannel;
 
   dataChannel.onopen = this._OnDataChannelOpen.bind(this);
+  dataChannel.onmessage = function(message) {
+    let element = document.getElementById('VDIClipboard');
+    element.value = message.data;
+  };
 
   peerConnection.createOffer(function(offer) {
     peerConnection.setLocalDescription(offer);
@@ -123,9 +145,10 @@ var PeerConnectionManager = function(videoElement, serverAddress, access_token) 
 PeerConnectionManager.prototype._OnDataChannelOpen = function() {
   var mouseManager = new MouseManager(this._videoElement, this._dataChannel);
   //var keyboardManager = new KeyboardManager(document.body, this._dataChannel);
-
+  var clipboardManager = new ClipboardManager(document.getElementById('getCloudClipboard'), document.getElementById('VDIClipboard'), this._dataChannel);
   return [
     mouseManager,
+    clipboardManager,
 //    keyboardManager
   ];
 };
@@ -166,5 +189,6 @@ PeerConnectionManager.prototype._OnAddStream = function(event) {
 export default {
   KeyboardManager,
   MouseManager,
+  ClipboardManager,
   PeerConnectionManager
 };

--- a/assets/app/vdi/topbar/template.hbs
+++ b/assets/app/vdi/topbar/template.hbs
@@ -38,7 +38,7 @@
           Upload
         </span>
       {{/icon-component}}
-      
+
     {{/if}}
 
     {{#icon-component
@@ -65,8 +65,9 @@
       click=(action "toggleWindow" 'clipboard')
       content="Copy / paste"
       size=16
+      id="setCloudClipboard"
     }}
-      <span class='va-tb hidden-sm-down'>
+      <span class='va-tb hidden-sm-down' id='getCloudClipboard'>
         Clipboard
       </span>
     {{/icon-component}}

--- a/photon/conductor.cc
+++ b/photon/conductor.cc
@@ -23,6 +23,8 @@
  */
 
 #include <iostream>
+#include <locale>
+#include <codecvt>
 
 #include <memory>
 #include <utility>
@@ -67,7 +69,7 @@ Conductor::Conductor(const std::string & offer,
   boost::shared_ptr<photon::http::server::response> res)
     : offer_(offer),
       response_(res) {
-	this->channel = nullptr;
+        this->channel = nullptr;
 }
 
 Conductor::~Conductor() {
@@ -172,15 +174,17 @@ void Conductor::OnMessage(const webrtc::DataBuffer& buffer) {
       break;
       // Set Clipboard
     case 'S': {
-      std::wstring wmess(mess.length(), 0); // Make room for characters
-      std::copy(mess.begin() + 1, mess.end(), wmess.begin());
-      input_manager_.SetClipboard(const_cast<std::wstring&>(wmess));
+      mess.erase(0, 1);
+      std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+      std::wstring wide = converter.from_bytes(mess);
+      input_manager_.SetClipboard(const_cast<std::wstring&>(wide));
       break;
    }
       // Send Clipboard
     case 'G': {
       std::wstring wide = input_manager_.GetClipboard();
-      std::string str(wide.begin(), wide.end());
+      std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+      std::string str = converter.to_bytes(wide);
       this->channel->Send(webrtc::DataBuffer(str));
       break;
     }

--- a/photon/conductor.h
+++ b/photon/conductor.h
@@ -100,8 +100,7 @@ protected:
       rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
   void OnRemoveStream(
       rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) override;
-  void OnDataChannel(
-      rtc::scoped_refptr<webrtc::DataChannelInterface> channel) override;
+  void OnDataChannel(webrtc::DataChannelInterface *channel) override;
   void OnRenegotiationNeeded() override {}
   void OnIceConnectionChange(
       webrtc::PeerConnectionInterface::IceConnectionState new_state) override{};
@@ -123,6 +122,7 @@ protected:
     peer_connection_factory_;
   std::map<std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface> >
     active_streams_;
+  rtc::scoped_refptr<webrtc::DataChannelInterface> channel;
 
 #if defined(WEBRTC_WIN)
   photon::InputManager input_manager_;

--- a/photon/input_manager.cc
+++ b/photon/input_manager.cc
@@ -132,13 +132,13 @@ const std::wstring InputManager::GetClipboard() {
   HANDLE       hData;
 
   if (!OpenClipboard(NULL))
-    return nullptr; // OpenClipboard fails
+    return std::wstring(); // OpenClipboard fails
 
   if (!(hData = GetClipboardData(CF_UNICODETEXT)))
-    return nullptr; // GetClipboardData returned null
+    return std::wstring(); // GetClipboardData returned null
 
   if ((buffer = (wchar_t *)GlobalLock(hData)) == NULL)
-    return nullptr; // Returned buffer is null
+    return std::wstring(); // Returned buffer is null
 
   GlobalUnlock(hData);
   CloseClipboard();

--- a/photon/input_manager.cc
+++ b/photon/input_manager.cc
@@ -106,4 +106,43 @@ void InputManager::MouseWheelEvent(int x) {
   );
 }
 
+void InputManager::SetClipboard(const std::wstring & data) {
+  if (OpenClipboard(0))
+  {
+    HGLOBAL hgClipBuffer = nullptr;
+    std::size_t sizeInWords = data.size() + 1;
+    std::size_t sizeInBytes = sizeInWords * sizeof(wchar_t);
+    hgClipBuffer = GlobalAlloc(GHND | GMEM_SHARE, sizeInBytes);
+    if (!hgClipBuffer)
+    {
+      CloseClipboard();
+      return ;
+    }
+    wchar_t *wgClipBoardBuffer = static_cast<wchar_t*>(GlobalLock(hgClipBuffer));
+    wcscpy_s(wgClipBoardBuffer, sizeInWords, data.c_str());
+    GlobalUnlock(hgClipBuffer);
+    EmptyClipboard();
+    SetClipboardData(CF_UNICODETEXT, hgClipBuffer);
+    CloseClipboard();
+  }
+}
+
+const std::wstring InputManager::GetClipboard() {
+  wchar_t      *buffer;
+  HANDLE       hData;
+
+  if (!OpenClipboard(NULL))
+    return nullptr; // OpenClipboard fails
+
+  if (!(hData = GetClipboardData(CF_UNICODETEXT)))
+    return nullptr; // GetClipboardData returned null
+
+  if ((buffer = (wchar_t *)GlobalLock(hData)) == NULL)
+    return nullptr; // Returned buffer is null
+
+  GlobalUnlock(hData);
+  CloseClipboard();
+  return std::wstring(buffer);
+}
+
 }  // namespace photon

--- a/photon/input_manager.h
+++ b/photon/input_manager.h
@@ -52,4 +52,4 @@ class InputManager {
 
 }  // namespace photon
 
-#endif  // PHOTON_INPUT_MANAG ER_H_
+#endif  // PHOTON_INPUT_MANAGER_H_

--- a/photon/input_manager.h
+++ b/photon/input_manager.h
@@ -26,6 +26,7 @@
 #define PHOTON_INPUT_MANAGER_H_
 
 #include <Windows.h>
+#include <string>
 
 #define KEY_SHIFT 0x10
 
@@ -40,6 +41,8 @@ class InputManager {
   void MouseMove(int x, int y);
   void MouseButtonEvent(char button, char state);
   void MouseWheelEvent(int x);
+  void SetClipboard(const std::wstring & data);
+  const std::wstring GetClipboard();
 
  private:
   void KeyEvent(char key, unsigned long flags);
@@ -49,4 +52,4 @@ class InputManager {
 
 }  // namespace photon
 
-#endif  // PHOTON_INPUT_MANAGER_H_
+#endif  // PHOTON_INPUT_MANAG ER_H_


### PR DESCRIPTION
This PR fixes #446.
Clipboard is sent from VM to the browser in a textarea when clicking on 'Clipboard' action on the VDI tab.
Clipboard is set automatically when the content of this textarea changes.
