### PR TITLE
Upgrade ember-cli

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -22,7 +22,7 @@
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "0.7.1",
     "ember-ckeditor": "0.0.1",
-    "ember-cli": "2.4.3",
+    "ember-cli": "2.9.1",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
A bug in ember-app prevent from building.
Upgrading to 2.9.1 fix the problem.
