### PR TITLE
Fix vdi can't load.

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -274,15 +274,15 @@ module.exports = {
               let username = null;
               let password = null;
 
-              if (user.ldapUser) {
-                // AD username is the same as the email
-                username = user.email;
-                password = user.ldapPassword;
-              } else {
-                username = machine.username;
-                password = machine.password;
-              }
               if (machine) {
+                if (user.ldapUser) {
+                  // AD username is the same as the email
+                  username = user.email;
+                  password = user.ldapPassword;
+                } else {
+                  username = machine.username;
+                  password = machine.password;
+                }
                 image.apps.forEach((app) => {
                   connections.push({
                     protocol: 'rdp',


### PR DESCRIPTION
Check if there is a machine before taking it username and password, for prevent crash (username of undefine).

To test:
 - Launch a vdi.
 - Create an image.
 - Close the vdi.
 - Launch a vdi on the new image

Expected result:
 - The vdi is launched correctly.