### PR TITLE
Fixe broker trying to create machines of size null

### DIFF
--- a/api/migrations/033_add_instance_size_per_image.js
+++ b/api/migrations/033_add_instance_size_per_image.js
@@ -22,10 +22,16 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-function up(knex) {
-  return knex.schema.table('image', function(t) {
-    t.string('instancesSize');
-  });
+function up(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('image', function(t) {
+      t.string('instancesSize');
+    }),
+
+    knex('image').update({
+      instancesSize: 'medium'
+    })
+  ]);
 }
 
 function down(knex) {


### PR DESCRIPTION
It was due of image instance size, who was null.
Set it to the default value (medium), when migrating.