### PR TITLE
Ldap users can sign in with their username alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Once loaded, Nanocloud will be accessible on **localhost**.
 - ldapActivated (defaults to false) if true activates LDAP features
 - ldapUrl (defaults to 'ldap://localhost:389')
 - ldapBaseDn (defaults to empty string)
+- ldapDomain (defaults to empty string)
 - ldapDefaultGroup (defaults to empty string (no default group)) id of the group users should be attached to automatically
 
 ## RDP/Guacamole Options

--- a/api/migrations/034_add_ldapusername_column_in_user.js
+++ b/api/migrations/034_add_ldapusername_column_in_user.js
@@ -1,0 +1,35 @@
+/**
+ * Nanocloud turns any traditional software into a cloud solution, without
+ * changing or redeveloping existing source code.
+ *
+ * Copyright (C) 2016 Nanocloud Software
+ *
+ * This file is part of Nanocloud.
+ *
+ * Nanocloud is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Nanocloud is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General
+ * Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+function up(knex) {
+  return knex.schema.table('user', (table) => {
+    table.string('ldapUsername');
+  });
+}
+
+function down(knex) {
+  return knex.schema.dropColumn('ldapUsername');
+}
+
+module.exports = { up, down };

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -84,6 +84,9 @@ module.exports = {
     ldapPassword: {
       type: 'string'
     },
+    ldapUsername: {
+      type: 'string'
+    },
 
     toJSON: function() {
       var obj = this.toObject();

--- a/assets/app/configuration/service.js
+++ b/assets/app/configuration/service.js
@@ -53,6 +53,7 @@ export default Ember.Service.extend({
     'ldapActivated',
     'ldapUrl',
     'ldapBaseDn',
+    'ldapDomain',
     'defaultGroupLdap',
     'photon',
     'instancesSize'

--- a/assets/app/protected/configs/ldap/template.hbs
+++ b/assets/app/protected/configs/ldap/template.hbs
@@ -25,6 +25,14 @@
         {{input-confirm placeholder=configController.ldapBaseDn value=configController.ldapBaseDn type="text"}}
       </div>
     </div>
+    <div class="form-group row m-t-1">
+      <div class="col-sm-2">
+        <p class="confirm-input-item color-primary in-bl fl va-sub">LDAP Domain</p>
+      </div>
+      <div class="col-sm-3">
+        {{input-confirm placeholder=configController.ldapDomain value=configController.ldapDomain type="text"}}
+      </div>
+    </div>
     {{#if model.groups.length}}
       <p class='m-t-1 color-primary'>You can select a default group</p>
       {{#each model.groups as |group|}}

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -123,6 +123,7 @@ module.exports = {
     ldapActivated: false,
     ldapUrl: 'ldap://localhost:389',
     ldapBaseDn: 'dc=nanocloud,dc=com',
+    ldapDomain: '',
     defaultGroupLdap: '',
 
     rdpPort: 3389,

--- a/config/passport.js
+++ b/config/passport.js
@@ -54,6 +54,13 @@ passport.use(
 
     function (username, password, done) {
 
+      // Check if username have @domain. If not we add @damain because `activedirectory` want username with the domain.
+      if (username.indexOf('@') < 0) {
+        ConfigService.get('ldapDomain')
+        .then((config) => {
+          username = username + '@' + config.ldapDomain;
+        });
+      }
       process.nextTick(
 
         function () {
@@ -79,6 +86,7 @@ passport.use(
 
                     let ldapUser = {
                       email: username,
+                      ldapUsername : user.sAMAccountName,
                       password: null, // we use the ldap password to authenticate ldap users
                       ldapPassword: password,
                       firstName: user.givenName,


### PR DESCRIPTION
Fixes #477 

Ldap user can now sign in with username alone.
Add `ldapDomain` config variable.
Add `ldapUsername` in user model.
The ldap user's email is determined as follows: `ldapUsername` + @ + `ldapDomain`
