### PR TITLE
Use machine username all time to start an application with Plaza

### DIFF
--- a/api/controllers/AppController.js
+++ b/api/controllers/AppController.js
@@ -145,15 +145,11 @@ module.exports = {
                 throw new Error('A machine is booting for you');
               }
 
-              let username = machine.username;
-              if (req.user.ldapUser === true) {
-                username = req.user.ldapUsername;
-              }
               return PlazaService.exec(machine.ip, machine.plazaport, {
                 command: [
                   app.filePath
                 ],
-                username: username,
+                username: machine.username,
               })
                 .then(() => {
                   return ConfigService.get('photon');

--- a/api/services/MachineService.js
+++ b/api/services/MachineService.js
@@ -416,7 +416,6 @@ function _createMachine(image) {
               })
               .then((machineWithGroup) => {
                 _createBrokerLog(machineWithGroup, 'Available');
-                return machineWithGroup.killSession();
               });
           }
         });

--- a/tests/unit/models/Image.test.js
+++ b/tests/unit/models/Image.test.js
@@ -70,7 +70,7 @@ describe('Images', () => {
             });
         })
         .then(() => {
-          return Image.destroy({ name: 'Parent image' });
+          return Image.update({ name: 'Parent image' }, {deleted: true});
         })
         .then(() => done());
     });


### PR DESCRIPTION
We don't use ldap username to launch an application with Plaza because Plaza can't deal with more than one user.