### PR TITLE
Fix guacamaole-client's build stopped working

### DIFF
--- a/guacamole-client/Dockerfile
+++ b/guacamole-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5.4-jre8
+FROM tomcat:8.5.13-jre8
 MAINTAINER Olivier Berthonneau <olivier.berthonneau@nanocloud.com>
 
 RUN apt-get update && apt-get -y install maven \


### PR DESCRIPTION
The following error was returned by APT:
The following packages have unmet dependencies:
```
 openjdk-8-jdk : Depends: openjdk-8-jre (= 8u121-b13-1~bpo8+1) but it is not going to be installed
                 Depends: openjdk-8-jdk-headless (= 8u121-b13-1~bpo8+1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

The reason for the sudden build breaking is unknown. Upgrading from tomcat 8.5.4 to 8.5.13 fixed the issue.