### PR TITLE
RFE: assign custom security groups #508

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ MACHINES=[{"name": "My Machine", "type": "manual", "ip": "1.2.3.4", "username": 
 - awsMachineUsername (Defaults to Administrator) administrator account on the machine
 - awsMachinePassword (Defaults to empty string, will be generated if possible) administrator password on the machine
 - awsMachineSubnet (Defaults to empty string, automatic subnet) subnet to assign to the machine
+- awsSecurityGroups (Defaults to empty array, will use 'default' security group in VPC) security group(s) to assign to the machine. For a nondefault VPC, you must use security group IDs instead.
+- awsSecurityGroupIds (Defaults to empty array, will use 'default' security group in VPC) security group(s) IDs to assign to the machine
+- awsMachineSubnet (Defaults to empty string, automatic subnet) subnet to assign to the machine
 - awsDiskSize (Defaults to 0, automatic size) root disk size in GB
 - creditLimit (Defaults empty string) set a credit limit to users (aws only)
 

--- a/api/drivers/aws/driver.js
+++ b/api/drivers/aws/driver.js
@@ -257,7 +257,7 @@ class AWSDriver extends Driver {
    */
   createMachine(machine, image) {
     return ConfigService.get('instancesSize', 'plazaURI', 'awsKeyName', 'plazaPort',
-      'awsMachineSubnet', 'awsDiskSize', 'awsMachineUsername', 'rdpPort')
+      'awsMachineSubnet', 'awsDiskSize', 'awsMachineUsername', 'rdpPort', 'awsSecurityGroups', 'awsSecurityGroupIds')
       .then((config) => {
 
         let userData = new Buffer(`<powershell>
@@ -298,6 +298,8 @@ class AWSDriver extends Driver {
             KeyName             : config.awsKeyName,
             UserData            : userData,
             SubnetId            : config.awsMachineSubnet,
+            SecurityGroups      : config.awsSecurityGroups,
+            SecurityGroupIds    : config.awsSecurityGroupIds,
             BlockDeviceMappings : diskOptions
           }, (err, server) => {
             if (err) {

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -103,6 +103,8 @@ module.exports = {
     awsMachineUsername: 'Administrator',
     awsMachinePassword: '',
     awsMachineSubnet: '',
+    awsSecurityGroup: null,
+    awsSecurityGroupIds: null,
     awsDiskSize: 0,
 
     openstackUsername:  '',


### PR DESCRIPTION
#508 Handling Security Groups and Security Group IDs for AWS

To attach custom security groups to your "nanocloud exec servers", proceed as follow:

From AWS console or using the aws-cli tool
- [ ] find your AWS SubNet ID
- [ ] find your AWS Security Group names or AWS Security Group IDs 

Then, configure your Nanocloud environment using the values just found by changing config/env/development or creating a config/local.js file
- [ ] set the 'awsMachineSubnet' parameter
- [ ] set either awsSecurityGroups or awsSecurityGroupIds parameter 

Sample config/local.js file:
```
module.exports = {
  nanocloud: {
    awsMachineSubnet: 'subnet-1a2b3c4d',
    awsSecurityGroupIds: ['sg-1a2b3c4d']
  }
```


You must choose Security Group(s) or Security Groups ID(s) that are define within the VPC containing the subnet referred to by the awsMachineSubnet parameter.

Configure only one of the two parameters. Setting both is useless and might result in provisioning error if they don't match.

Please note that using Security Group name(s) is only supported in EC2-Classic or in the default VPC, not in user-created VPCs. From AWS EC2 'runInstances' SDK function documentation
(http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#runInstances-property)

- SecurityGroups — (Array<String>)
[EC2-Classic, default VPC] One or more security group names. For a nondefault VPC, you must use security group IDs instead.

Default: Amazon EC2 uses the default security group.

- SecurityGroupIds — (Array<String>)
One or more security group IDs. You can create a security group using CreateSecurityGroup.

Default: Amazon EC2 uses the default security group.

Notes:
- couldn't find existing tests for the AWS driver at all, so example to start from to test these new parameters but tested them on my config and it works.